### PR TITLE
fix-cloud-build-test-target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,7 +49,6 @@ firebase-credentials.json
 .cursor
 docs
 infrastructure
-tests
 tools
 
 # Source-adjacent documentation is not used by the running application

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 
 - Install dependencies with `uv sync --locked --all-groups`.
 - Run `uv run pytest tests/unit -q`.
+- Run `docker build --target test --tag poke-math:test .` to validate the Linux test target used by Cloud Build.
 - Run `docker build --build-arg COMMIT_SHA=local --tag poke-math:local .`.
 - Ruff has a known baseline of pre-existing findings and is not a required delivery check until that baseline is deliberately cleaned up.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use official Python runtime
-FROM python:3.11-slim
+# Use the same Python and uv installation in test and production targets.
+FROM python:3.11-slim AS base
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -9,13 +9,29 @@ ENV PYTHONPATH=/app
 # Create app directory
 WORKDIR /app
 
-# Install locked production dependencies first. Keep the virtual environment in
-# the application directory for a self-contained runtime.
+# Install the pinned uv binary once for every target derived from this base.
 COPY --from=ghcr.io/astral-sh/uv:0.11.26 /uv /usr/local/bin/uv
+
+# Dependency metadata changes less often than source files, preserving Docker's
+# cache for both test and production dependency installation.
 COPY pyproject.toml uv.lock ./
+
+FROM base AS production-dependencies
 RUN uv sync --locked --no-dev
 
-# Add build argument for commit SHA - moved down since it changes frequently
+# The test target extends the exact production dependency environment, then adds
+# only the locked development dependencies required to run the unit suite.
+FROM production-dependencies AS test
+RUN uv sync --locked --group dev
+COPY pytest.ini ./
+COPY src ./src
+COPY tests ./tests
+RUN uv run --locked --no-sync pytest tests/unit -q
+
+FROM production-dependencies AS runtime
+
+# Add build argument for commit SHA after dependency installation so it does not
+# invalidate dependency layers.
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ RUN uv run --locked --no-sync pytest tests/unit -q
 
 FROM production-dependencies AS runtime
 
+# The application needs only read access to its source and virtual environment.
+# Run the web server without root privileges in the final image.
+RUN useradd --system --create-home --shell /usr/sbin/nologin appuser
+USER appuser
+
 # Add build argument for commit SHA after dependency installation so it does not
 # invalidate dependency layers.
 ARG COMMIT_SHA

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,13 @@
 steps:
-  - name: ghcr.io/astral-sh/uv:0.11.26-python3.11-bookworm-slim
+  # The test target uses the same pinned Python and uv setup as the production
+  # target. A failed test prevents the image build, push, and deployment steps.
+  - name: gcr.io/cloud-builders/docker
     id: test
-    entrypoint: sh
     args:
-      - -c
-      - uv sync --locked --group dev && uv run --locked --no-sync pytest tests/unit -q
+      - build
+      - --target
+      - test
+      - .
 
   - name: gcr.io/cloud-builders/docker
     id: build

--- a/docs/plans/remote-agent-delivery-plan.md
+++ b/docs/plans/remote-agent-delivery-plan.md
@@ -79,7 +79,8 @@ uv sync --locked --group dev
 
 ### Implementation status: 2026-07-20
 
-- Completed in the repository: Python dependencies are managed by `uv` with a committed lockfile; root agent guidance documents Python 3.11, setup, validation, cloud-environment, and delivery boundaries; CI defines `unit-tests` and `docker-build`; Cloud Build runs the locked unit suite before build, push, and deploy.
+- Completed in the repository: Python dependencies are managed by `uv` with a committed lockfile; root agent guidance documents Python 3.11, setup, validation, cloud-environment, and delivery boundaries; CI defines `unit-tests` and `docker-build`.
+- Cloud Build correction in progress: the initial deployment of merge commit `0068fc45c9b69887a988b5ea136f29d37d8b5b74` failed before tests because the selected `ghcr.io/astral-sh/uv:0.11.26-python3.11-bookworm-slim` manifest does not exist. The correction makes Cloud Build build the Dockerfile's `test` target, which uses the same pinned Python 3.11 and `uv` setup as the runtime target, adds only locked development dependencies, and runs the unit suite before the production image build. Hosted verification remains required before Cloud Build can be recorded as passing.
 - Verified locally in a managed Python 3.11 environment: `uv lock --check` and `uv run --locked --group dev pytest tests/unit -q` (74 passed). The Docker build remains to be run by GitHub Actions or a Docker-capable environment.
 - Still external and intentionally not changed: personal GitHub CLI reauthentication, Codex cloud-repository/environment setup, GitHub `main` branch protection, Cloud Build trigger/connection verification, remote pull-request rehearsal, production deployment observation, and rollback rehearsal.
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -75,7 +75,7 @@ Run from the repository root:
 .\infrastructure\scripts\deploy.ps1
 ```
 
-The script runs unit tests, verifies that `.gcloudignore` admits only the container recipe, locked dependency metadata, application source, and tests, checks the upload set for local credentials, and submits an asynchronous build under the dedicated build identity. Cloud Build runs the same unit suite before it builds, pushes, and deploys. The Dockerfile copies only the application source and dependency metadata into the runtime image. The build tags the image immutably and updates only the Cloud Run image; it preserves the service's current public/private IAM state.
+The script runs unit tests, verifies that `.gcloudignore` admits only the container recipe, locked dependency metadata, application source, and tests, checks the upload set for local credentials, and submits an asynchronous build under the dedicated build identity. Cloud Build first builds the Dockerfile's `test` target, which runs the locked unit suite with the same Python and `uv` setup as the runtime target, before it builds, pushes, and deploys the final image. The runtime target copies only the application source and dependency metadata into the runtime image. The build tags the image immutably and updates only the Cloud Run image; it preserves the service's current public/private IAM state.
 
 Inspect the returned build ID:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Docker-based test stage that runs the locked unit test suite using the same environment as the application runtime.
  * Cloud Build now validates tests before building, pushing, or deploying the application image.

* **Documentation**
  * Updated deployment guidance with details about uploaded files, test validation, and the Cloud Build workflow.

* **Chores**
  * Included the test suite in Docker build contexts for reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->