### PR TITLE
Modernize Ruff configuration and fix lint findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,28 +31,20 @@ dev = [
 package = false
 
 [tool.ruff]
-# Exclude a variety of commonly ignored directories.
-exclude = [
-    ".git",
-    ".venv",
-    "venv",
-    "__pycache__",
-    ".pytest_cache",
-]
-
-# Match the supported runtime.
+line-length = 100
+src = ["src", "tests", "tools"]
 target-version = "py311"
 
 [tool.ruff.lint]
-# Enable pycodestyle, Pyflakes, flake8-bugbear, and import sorting. The legacy
-# codebase is not line-wrapped consistently, so E501 is intentionally deferred.
-select = ["E", "F", "B", "I"]
 ignore = ["E501"]
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-
-[tool.ruff.lint.per-file-ignores]
-# Tests can use magic values, assertions, and relative imports
-"tests/**/*" = ["PLR2004", "S101", "TID252"]
+select = [
+    "B",   # flake8-bugbear: likely bugs and footguns
+    "E",   # pycodestyle errors
+    "F",   # Pyflakes
+    "I",   # isort
+    "RUF", # Ruff-specific rules
+    "UP",  # pyupgrade
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["src"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """
 PokeMath source package.
-""" 
+"""

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,3 +1,3 @@
 """
 PokeMath application package.
-""" 
+"""

--- a/src/app/__main__.py
+++ b/src/app/__main__.py
@@ -10,4 +10,4 @@ from src.app.app import app
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 8080))
-    app.run(host="0.0.0.0", port=port, debug=os.environ.get("FLASK_ENV") == "development") 
+    app.run(host="0.0.0.0", port=port, debug=os.environ.get("FLASK_ENV") == "development")

--- a/src/app/app.py
+++ b/src/app/app.py
@@ -16,7 +16,7 @@ import os
 import secrets
 from functools import wraps
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from flask import (
     Flask,
@@ -48,6 +48,7 @@ from src.app.view_models import QuizResultViewModel, QuizViewModel
 # Authentication Helper
 # -----------------------------------------------------------------------------
 
+
 def login_required(f):
     """
     Decorator to require authentication for routes.
@@ -58,7 +59,7 @@ def login_required(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         if not AuthManager.is_authenticated():
-            return redirect(url_for('login'))
+            return redirect(url_for("login"))
         return f(*args, **kwargs)
 
     return decorated_function
@@ -68,74 +69,75 @@ def login_required(f):
 # Application Setup and Configuration
 # -----------------------------------------------------------------------------
 
+
 def create_flask_app():
     """
     Create and configure the Flask application.
-    
+
     Returns:
         Flask: Configured Flask application
     """
-    flask_app = Flask(__name__,
-                      template_folder=str(Path(__file__).parent.parent / 'templates'),
-                      static_folder=str(Path(__file__).parent.parent / 'static'))
+    flask_app = Flask(
+        __name__,
+        template_folder=str(Path(__file__).parent.parent / "templates"),
+        static_folder=str(Path(__file__).parent.parent / "static"),
+    )
     environment = os.environ.get(
-        'APP_ENVIRONMENT', os.environ.get('FLASK_ENV', 'development')
+        "APP_ENVIRONMENT", os.environ.get("FLASK_ENV", "development")
     ).lower()
-    is_production = environment == 'production'
+    is_production = environment == "production"
 
-    session_secret = os.environ.get('FLASK_SECRET_KEY')
+    session_secret = os.environ.get("FLASK_SECRET_KEY")
     if is_production and not session_secret:
-        raise RuntimeError('FLASK_SECRET_KEY is required in production')
+        raise RuntimeError("FLASK_SECRET_KEY is required in production")
     if not session_secret:
         # Local-only ephemeral key. Production must inject a stable secret.
         session_secret = secrets.token_urlsafe(32)
 
     flask_app.config.update(
         SECRET_KEY=session_secret,
-        WTF_CSRF_SECRET_KEY=os.environ.get('WTF_CSRF_SECRET_KEY', session_secret),
+        WTF_CSRF_SECRET_KEY=os.environ.get("WTF_CSRF_SECRET_KEY", session_secret),
         WTF_CSRF_ENABLED=True,
         WTF_CSRF_TIME_LIMIT=3600,
         WTF_CSRF_CHECK_DEFAULT=True,
-        WTF_CSRF_METHODS=['POST', 'PUT', 'PATCH', 'DELETE'],
+        WTF_CSRF_METHODS=["POST", "PUT", "PATCH", "DELETE"],
         SESSION_COOKIE_HTTPONLY=True,
-        SESSION_COOKIE_SAMESITE='Lax',
+        SESSION_COOKIE_SAMESITE="Lax",
         SESSION_COOKIE_SECURE=is_production,
-        PREFERRED_URL_SCHEME='https' if is_production else 'http',
-        REQUEST_RATE_LIMIT_ENABLED=_environment_bool(
-            'REQUEST_RATE_LIMIT_ENABLED', is_production
-        ),
+        PREFERRED_URL_SCHEME="https" if is_production else "http",
+        REQUEST_RATE_LIMIT_ENABLED=_environment_bool("REQUEST_RATE_LIMIT_ENABLED", is_production),
         REQUEST_RATE_LIMIT_GLOBAL_PER_MINUTE=int(
-            os.environ.get('REQUEST_RATE_LIMIT_GLOBAL_PER_MINUTE', '300')
+            os.environ.get("REQUEST_RATE_LIMIT_GLOBAL_PER_MINUTE", "300")
         ),
         REQUEST_RATE_LIMIT_CLIENT_PER_MINUTE=int(
-            os.environ.get('REQUEST_RATE_LIMIT_CLIENT_PER_MINUTE', '120')
+            os.environ.get("REQUEST_RATE_LIMIT_CLIENT_PER_MINUTE", "120")
         ),
         REQUEST_RATE_LIMIT_AUTH_GLOBAL_PER_MINUTE=int(
-            os.environ.get('REQUEST_RATE_LIMIT_AUTH_GLOBAL_PER_MINUTE', '60')
+            os.environ.get("REQUEST_RATE_LIMIT_AUTH_GLOBAL_PER_MINUTE", "60")
         ),
         REQUEST_RATE_LIMIT_AUTH_CLIENT_PER_MINUTE=int(
-            os.environ.get('REQUEST_RATE_LIMIT_AUTH_CLIENT_PER_MINUTE', '10')
+            os.environ.get("REQUEST_RATE_LIMIT_AUTH_CLIENT_PER_MINUTE", "10")
         ),
         REQUEST_RATE_LIMIT_WRITE_GLOBAL_PER_MINUTE=int(
-            os.environ.get('REQUEST_RATE_LIMIT_WRITE_GLOBAL_PER_MINUTE', '120')
+            os.environ.get("REQUEST_RATE_LIMIT_WRITE_GLOBAL_PER_MINUTE", "120")
         ),
         REQUEST_RATE_LIMIT_WRITE_CLIENT_PER_MINUTE=int(
-            os.environ.get('REQUEST_RATE_LIMIT_WRITE_CLIENT_PER_MINUTE', '30')
+            os.environ.get("REQUEST_RATE_LIMIT_WRITE_CLIENT_PER_MINUTE", "30")
         ),
     )
 
     _register_request_fuse(flask_app, trust_forwarded_for=is_production)
     CSRFProtect(flask_app)
 
-    @flask_app.get('/readyz')
+    @flask_app.get("/readyz")
     def readyz():
         """Liveness check that does not touch Firebase or Firestore."""
-        return jsonify({'status': 'ok'})
+        return jsonify({"status": "ok"})
 
     # Add version info to all templates
     @flask_app.context_processor
     def inject_version_info():
-        return {'version_info': get_version_info()}
+        return {"version_info": get_version_info()}
 
     return flask_app
 
@@ -144,7 +146,7 @@ def _environment_bool(name: str, default: bool) -> bool:
     value = os.environ.get(name)
     if value is None:
         return default
-    return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _register_request_fuse(flask_app: Flask, *, trust_forwarded_for: bool) -> None:
@@ -152,39 +154,39 @@ def _register_request_fuse(flask_app: Flask, *, trust_forwarded_for: bool) -> No
 
     @flask_app.before_request
     def enforce_request_fuse():
-        if not flask_app.config['REQUEST_RATE_LIMIT_ENABLED']:
+        if not flask_app.config["REQUEST_RATE_LIMIT_ENABLED"]:
             return None
-        if request.endpoint == 'readyz':
+        if request.endpoint == "readyz":
             return None
 
         limits = [
             RateLimit(
-                'all',
-                flask_app.config['REQUEST_RATE_LIMIT_GLOBAL_PER_MINUTE'],
-                flask_app.config['REQUEST_RATE_LIMIT_CLIENT_PER_MINUTE'],
+                "all",
+                flask_app.config["REQUEST_RATE_LIMIT_GLOBAL_PER_MINUTE"],
+                flask_app.config["REQUEST_RATE_LIMIT_CLIENT_PER_MINUTE"],
             )
         ]
-        if request.endpoint == 'auth_callback':
+        if request.endpoint == "auth_callback":
             limits.append(
                 RateLimit(
-                    'auth',
-                    flask_app.config['REQUEST_RATE_LIMIT_AUTH_GLOBAL_PER_MINUTE'],
-                    flask_app.config['REQUEST_RATE_LIMIT_AUTH_CLIENT_PER_MINUTE'],
+                    "auth",
+                    flask_app.config["REQUEST_RATE_LIMIT_AUTH_GLOBAL_PER_MINUTE"],
+                    flask_app.config["REQUEST_RATE_LIMIT_AUTH_CLIENT_PER_MINUTE"],
                 )
             )
-        if request.method not in {'GET', 'HEAD', 'OPTIONS'}:
+        if request.method not in {"GET", "HEAD", "OPTIONS"}:
             limits.append(
                 RateLimit(
-                    'write',
-                    flask_app.config['REQUEST_RATE_LIMIT_WRITE_GLOBAL_PER_MINUTE'],
-                    flask_app.config['REQUEST_RATE_LIMIT_WRITE_CLIENT_PER_MINUTE'],
+                    "write",
+                    flask_app.config["REQUEST_RATE_LIMIT_WRITE_GLOBAL_PER_MINUTE"],
+                    flask_app.config["REQUEST_RATE_LIMIT_WRITE_CLIENT_PER_MINUTE"],
                 )
             )
 
         decision = limiter.check(
             client_identifier(
                 request.remote_addr,
-                request.headers.get('X-Forwarded-For'),
+                request.headers.get("X-Forwarded-For"),
                 trust_forwarded_for=trust_forwarded_for,
             ),
             limits,
@@ -192,26 +194,26 @@ def _register_request_fuse(flask_app: Flask, *, trust_forwarded_for: bool) -> No
         if decision.allowed:
             return None
 
-        response = jsonify({
-            'error': 'Too many requests',
-            'retry_after': decision.retry_after,
-        })
+        response = jsonify(
+            {
+                "error": "Too many requests",
+                "retry_after": decision.retry_after,
+            }
+        )
         response.status_code = 429
-        response.headers['Retry-After'] = str(decision.retry_after)
-        response.headers['Cache-Control'] = 'no-store'
+        response.headers["Retry-After"] = str(decision.retry_after)
+        response.headers["Cache-Control"] = "no-store"
         return response
 
 
 def get_version_info():
     """
     Get application version information from environment.
-    
+
     Returns:
         dict: Version information
     """
-    return {
-        'version': os.environ.get('COMMIT_SHA', 'development')
-    }
+    return {"version": os.environ.get("COMMIT_SHA", "development")}
 
 
 # -----------------------------------------------------------------------------
@@ -227,13 +229,13 @@ app = create_flask_app()
 def after_request(response):
     """
     Process response after each request.
-    
+
     This function:
     1. Sets the guest cookie for guest users
-    
+
     Args:
         response: Flask response object
-        
+
     Returns:
         Modified response
     """
@@ -244,12 +246,12 @@ def after_request(response):
 
 
 # Load game configuration
-GAME_CONFIG_PATH = Path(__file__).parent.parent / 'data' / 'quizzes.json'
-POKEMON_CONFIG_PATH = Path(__file__).parent.parent / 'data' / 'pokemons.json'
+GAME_CONFIG_PATH = Path(__file__).parent.parent / "data" / "quizzes.json"
+POKEMON_CONFIG_PATH = Path(__file__).parent.parent / "data" / "pokemons.json"
 GAME_CONFIG = load_game_config(GAME_CONFIG_PATH, POKEMON_CONFIG_PATH)
 
 # Load equation difficulties
-DIFFICULTY_CONFIG_PATH = Path(__file__).parent.parent / 'data' / 'equation_difficulties_v2.json'
+DIFFICULTY_CONFIG_PATH = Path(__file__).parent.parent / "data" / "equation_difficulties_v2.json"
 EQUATION_DIFFICULTIES = load_equation_difficulties(DIFFICULTY_CONFIG_PATH)
 
 # Create equation generator
@@ -263,13 +265,14 @@ POKEMON_IMAGES = [pokemon.image_path for pokemon in GAME_CONFIG.pokemons.values(
 # Helper Functions
 # -----------------------------------------------------------------------------
 
+
 def create_game_manager() -> GameManager:
     """
     Create a GameManager instance with session data loaded from persistent storage.
-    
+
     Returns:
         GameManager: Instance with loaded session data
-        
+
     Raises:
         Exception: If Firestore storage is enabled but not available
     """
@@ -287,15 +290,16 @@ def create_game_manager() -> GameManager:
         raise
 
 
-def process_quiz_answers(user_answers: Dict[str, int],
-                         expected_answers: Dict[str, Union[int, str]]) -> QuizResultViewModel:
+def process_quiz_answers(
+    user_answers: dict[str, int], expected_answers: dict[str, int | str]
+) -> QuizResultViewModel:
     """
     Process quiz answers for both random and regular quizzes.
-    
+
     Args:
         user_answers: Dictionary of user-provided answers {var: value}
         expected_answers: Dictionary of expected answers {var: value}
-        
+
     Returns:
         QuizResultViewModel: Standardized result object containing quiz results data
     """
@@ -326,40 +330,41 @@ def process_quiz_answers(user_answers: Dict[str, int],
         correct_answers=correct_answers,
         all_answered=all_answered,
         correct_count=correct_count,
-        total_count=total_count
+        total_count=total_count,
     )
 
 
-def parse_user_answers(form_data: Dict[str, str], solution_keys: List[str]) -> Dict[str, int]:
+def parse_user_answers(form_data: dict[str, str], solution_keys: list[str]) -> dict[str, int]:
     """
     Parse and filter user answers from form data.
-    
+
     Args:
         form_data: Form data from request
         solution_keys: Keys expected in the solution
-        
+
     Returns:
         Dict[str, int]: Filtered and parsed user answers
     """
     return {
         key: int(value)
         for key, value in form_data.items()
-        if value.strip() and key in solution_keys  # Only include non-empty values for solution variables
+        if value.strip()
+        and key in solution_keys  # Only include non-empty values for solution variables
     }
 
 
 def render_quiz_template(
-        is_random: bool,
-        quiz_data: Dict[str, Any],
-        image_mapping: Dict[str, str],
-        result: Optional[QuizResultViewModel] = None,
-        user_answers: Optional[Dict[str, int]] = None,
-        already_solved: bool = False,
-        adventure_results: Optional[Dict[str, Any]] = None
+    is_random: bool,
+    quiz_data: dict[str, Any],
+    image_mapping: dict[str, str],
+    result: QuizResultViewModel | None = None,
+    user_answers: dict[str, int] | None = None,
+    already_solved: bool = False,
+    adventure_results: dict[str, Any] | None = None,
 ) -> Any:
     """
     Render the quiz template for both random and regular quizzes.
-    
+
     Args:
         is_random: Whether this is a random quiz
         quiz_data: Quiz data in unified dictionary format
@@ -368,7 +373,7 @@ def render_quiz_template(
         user_answers: Optional dictionary of user submitted answers
         already_solved: Flag indicating if the quiz is already solved
         adventure_results: Optional dictionary with adventure completion results
-        
+
     Returns:
         Response: Flask response with rendered template
     """
@@ -377,39 +382,40 @@ def render_quiz_template(
 
     # Create a strongly-typed view model
     quiz = QuizViewModel(
-        id=quiz_data.get('quiz_id', ''),
-        title=quiz_data.get('title', 'Random Mission' if is_random else 'Quiz'),
-        equations=quiz_data.get('equations', []),
-        variables=list(quiz_data.get('solution', {}).keys()),
+        id=quiz_data.get("quiz_id", ""),
+        title=quiz_data.get("title", "Random Mission" if is_random else "Quiz"),
+        equations=quiz_data.get("equations", []),
+        variables=list(quiz_data.get("solution", {}).keys()),
         image_mapping=image_mapping,
-        description=quiz_data.get('description', ''),
+        description=quiz_data.get("description", ""),
         is_random=is_random,
-        difficulty=quiz_data.get('difficulty'),
-        next_quiz_id=quiz_data.get('next_quiz_id'),
-        has_next=quiz_data.get('next_quiz_id') is not None
+        difficulty=quiz_data.get("difficulty"),
+        next_quiz_id=quiz_data.get("next_quiz_id"),
+        has_next=quiz_data.get("next_quiz_id") is not None,
     )
 
     template_args = {
-        'quiz': quiz,  # Strongly typed view model
-        'result': result,
-        'user_answers': user_answers,
-        'already_solved': already_solved,
-        'adventure_results': adventure_results
+        "quiz": quiz,  # Strongly typed view model
+        "result": result,
+        "user_answers": user_answers,
+        "already_solved": already_solved,
+        "adventure_results": adventure_results,
     }
 
-    return render_template('quiz.html', **template_args)
+    return render_template("quiz.html", **template_args)
 
 
 # -----------------------------------------------------------------------------
 # Route Handlers
 # -----------------------------------------------------------------------------
 
-@app.route('/')
+
+@app.route("/")
 @login_required
 def index():
     """
     Display the home page.
-    
+
     Returns:
         Rendered index page template
     """
@@ -417,21 +423,23 @@ def index():
     session_manager = create_session_manager()
     user_name = session_manager.get_user_name()
 
-    return render_template('index.html', user_name=user_name)
+    return render_template("index.html", user_name=user_name)
 
 
-@app.route('/exercises')
+@app.route("/exercises")
 @login_required
 def all_exercises():
     """Display all available community exercises."""
     game_manager = create_game_manager()
-    return render_template('all_exercises.html',
-                           title="Community Exercises",
-                           sections=GAME_CONFIG.sections,
-                           solved_quizzes=game_manager.session_manager.solved_quizzes)
+    return render_template(
+        "all_exercises.html",
+        title="Community Exercises",
+        sections=GAME_CONFIG.sections,
+        solved_quizzes=game_manager.session_manager.solved_quizzes,
+    )
 
 
-@app.route('/profile')
+@app.route("/profile")
 @login_required
 def profile():
     """
@@ -459,45 +467,48 @@ def profile():
     for pokemon_id, count in caught_pokemon.items():
         if pokemon_id in game_manager.game_config.pokemons:
             pokemon = game_manager.game_config.pokemons[pokemon_id]
-            collection.append({
-                'id': pokemon_id,
-                'name': pokemon.name,
-                'image_path': pokemon.image_path,
-                'count': count
-            })
+            collection.append(
+                {
+                    "id": pokemon_id,
+                    "name": pokemon.name,
+                    "image_path": pokemon.image_path,
+                    "count": count,
+                }
+            )
 
     # Sort by name
-    collection.sort(key=lambda p: p['name'])
+    collection.sort(key=lambda p: p["name"])
 
     # Calculate totals
     total_unique_pokemon = len(caught_pokemon)
     total_available_pokemon = len(game_manager.game_config.pokemons)
 
-    return render_template('profile.html',
-                           points=points,
-                           solved_count=solved_count,
-                           user_name=user_name,
-                           is_guest=is_guest,
-                           level_info=level_info,
-                           collection=collection,
-                           total_unique_pokemon=total_unique_pokemon,
-                           total_available_pokemon=total_available_pokemon)
+    return render_template(
+        "profile.html",
+        points=points,
+        solved_count=solved_count,
+        user_name=user_name,
+        is_guest=is_guest,
+        level_info=level_info,
+        collection=collection,
+        total_unique_pokemon=total_unique_pokemon,
+        total_available_pokemon=total_available_pokemon,
+    )
 
 
-@app.route('/new-exercise')
+@app.route("/new-exercise")
 @login_required
 def new_exercise():
     """Display difficulty selection screen for random exercise generation."""
-    return render_template('new_exercise.html',
-                           difficulties=EQUATION_DIFFICULTIES)
+    return render_template("new_exercise.html", difficulties=EQUATION_DIFFICULTIES)
 
 
-@app.route('/generate-random-exercise/<difficulty_id>')
+@app.route("/generate-random-exercise/<difficulty_id>")
 @login_required
 def generate_random_exercise(difficulty_id):
     """Generate a random exercise based on the selected difficulty."""
     # Find the selected difficulty
-    selected_difficulty = next((d for d in EQUATION_DIFFICULTIES if d['id'] == difficulty_id), None)
+    selected_difficulty = next((d for d in EQUATION_DIFFICULTIES if d["id"] == difficulty_id), None)
 
     if not selected_difficulty:
         return "Difficulty not found", 404
@@ -506,22 +517,19 @@ def generate_random_exercise(difficulty_id):
 
     # Get the player's current level
     level_info = game_manager.get_player_level_info()
-    player_level = level_info['level']
+    player_level = level_info["level"]
 
     random_quiz_id, quiz_data = generate_random_quiz_data(
-        GAME_CONFIG,
-        selected_difficulty,
-        EQUATION_GENERATOR,
-        player_level=player_level
+        GAME_CONFIG, selected_difficulty, EQUATION_GENERATOR, player_level=player_level
     )
 
     # Store the quiz in the session manager
     game_manager.session_manager.save_quiz_data(random_quiz_id, quiz_data, is_random=True)
 
-    return redirect(url_for('quiz', quiz_id=random_quiz_id))
+    return redirect(url_for("quiz", quiz_id=random_quiz_id))
 
 
-@app.route('/quiz/<quiz_id>', methods=['GET', 'POST'])
+@app.route("/quiz/<quiz_id>", methods=["GET", "POST"])
 @login_required
 def quiz(quiz_id):
     """
@@ -530,7 +538,7 @@ def quiz(quiz_id):
     game_manager = create_game_manager()
 
     # Check if this is a random quiz ID format
-    is_random = quiz_id.startswith('random_')
+    is_random = quiz_id.startswith("random_")
 
     # Get quiz data from session manager
     session_manager = game_manager.session_manager
@@ -543,24 +551,24 @@ def quiz(quiz_id):
             quiz_state = game_manager.get_quiz_state(quiz_id)
             if quiz_state:
                 # Convert to unified format
-                quiz = quiz_state['quiz']
+                quiz = quiz_state["quiz"]
                 regular_quiz_data = {
-                    'quiz_id': quiz_id,
-                    'title': quiz.title,
-                    'description': quiz.description,
-                    'equations': quiz.equations,
-                    'solution': quiz.answer.values,
-                    'image_mapping': quiz_state['image_mapping'],
-                    'next_quiz_id': quiz.next_quiz_id,
-                    'is_random': False
+                    "quiz_id": quiz_id,
+                    "title": quiz.title,
+                    "description": quiz.description,
+                    "equations": quiz.equations,
+                    "solution": quiz.answer.values,
+                    "image_mapping": quiz_state["image_mapping"],
+                    "next_quiz_id": quiz.next_quiz_id,
+                    "is_random": False,
                 }
                 quiz_data = regular_quiz_data
                 session_manager.save_quiz_data(quiz_id, quiz_data, is_random=False)
             else:
-                return render_template('quiz_not_found.html', quiz_id=quiz_id)
+                return render_template("quiz_not_found.html", quiz_id=quiz_id)
         else:
             # Random quiz not found - simply return not found page
-            return render_template('quiz_not_found.html', quiz_id=quiz_id)
+            return render_template("quiz_not_found.html", quiz_id=quiz_id)
 
     # Check if this quiz is already solved
     already_solved = game_manager.session_manager.is_quiz_solved(quiz_id)
@@ -571,26 +579,26 @@ def quiz(quiz_id):
     # Pre-populate answers if the quiz is already solved and user hasn't entered anything
     if already_solved and not user_answers:
         # Show the correct answers for an already solved quiz
-        user_answers = {var: int(float(val)) for var, val in quiz_data['solution'].items()}
+        user_answers = {var: int(float(val)) for var, val in quiz_data["solution"].items()}
         session_manager.save_quiz_answers(quiz_id, user_answers)
 
     # Initialize adventure results data
     adventure_results = None
 
     # Handle form submission
-    if request.method == 'POST':
+    if request.method == "POST":
         # If the quiz is already solved, don't process the answers again
         if already_solved:
-            return render_template('already_solved.html', quiz_id=quiz_id)
+            return render_template("already_solved.html", quiz_id=quiz_id)
 
         # Parse user answers
-        user_answers = parse_user_answers(request.form, quiz_data['solution'].keys())
+        user_answers = parse_user_answers(request.form, quiz_data["solution"].keys())
 
         # Save the answers
         session_manager.save_quiz_answers(quiz_id, user_answers)
 
         # Check answers
-        result = process_quiz_answers(user_answers, quiz_data['solution'])
+        result = process_quiz_answers(user_answers, quiz_data["solution"])
 
         # Update session data if all answers are correct
         if result.correct:
@@ -598,14 +606,14 @@ def quiz(quiz_id):
 
             # Process adventure completion if the quiz was solved correctly
             # Determine difficulty level
-            difficulty = quiz_data.get('difficulty').get('difficulty')
+            difficulty = quiz_data.get("difficulty").get("difficulty")
 
             # Determine which Pokémon to catch based on the quiz
             # For now, we'll use the Pokémon from the image mapping as the caught Pokémon
             caught_pokemon = []
-            for _var, img_path in quiz_data['image_mapping'].items():
+            for _var, img_path in quiz_data["image_mapping"].items():
                 # Extract Pokémon ID from image path (remove file extension)
-                pokemon_id = img_path.split('.')[0]
+                pokemon_id = img_path.split(".")[0]
                 if pokemon_id not in caught_pokemon:
                     caught_pokemon.append(pokemon_id)
 
@@ -625,55 +633,53 @@ def quiz(quiz_id):
             for pokemon_id in caught_pokemon:
                 if pokemon_id in game_manager.game_config.pokemons:
                     pokemon = game_manager.game_config.pokemons[pokemon_id]
-                    caught_pokemon_details.append({
-                        'id': pokemon_id,
-                        'name': pokemon.name,
-                        'image_path': pokemon.image_path
-                    })
+                    caught_pokemon_details.append(
+                        {"id": pokemon_id, "name": pokemon.name, "image_path": pokemon.image_path}
+                    )
 
             # Create adventure results data
             adventure_results = {
-                'caught_pokemon': caught_pokemon_details,
-                'pokemon_counts': pokemon_counts,
-                'xp_gained': rewards['xp_reward'],
-                'leveled_up': rewards['leveled_up'],
-                'level_info': level_info
+                "caught_pokemon": caught_pokemon_details,
+                "pokemon_counts": pokemon_counts,
+                "xp_gained": rewards["xp_reward"],
+                "leveled_up": rewards["leveled_up"],
+                "level_info": level_info,
             }
 
             # Add adventure results to the result dictionary for AJAX requests
             result_dict = result.to_dict()
-            result_dict['adventure_results'] = adventure_results
+            result_dict["adventure_results"] = adventure_results
 
             # If it's an AJAX request, return JSON with adventure results
-            if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            if request.headers.get("X-Requested-With") == "XMLHttpRequest":
                 return jsonify(result_dict)
         else:
             # If it's an AJAX request, return JSON without adventure results
-            if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            if request.headers.get("X-Requested-With") == "XMLHttpRequest":
                 return jsonify(result.to_dict())
 
         # For regular form submissions
         return render_quiz_template(
             is_random=is_random,
             quiz_data=quiz_data,
-            image_mapping=quiz_data['image_mapping'],
+            image_mapping=quiz_data["image_mapping"],
             result=result,
             user_answers=user_answers,
             already_solved=already_solved,
-            adventure_results=adventure_results
+            adventure_results=adventure_results,
         )
 
     # GET request - just display the quiz
     return render_quiz_template(
         is_random=is_random,
         quiz_data=quiz_data,
-        image_mapping=quiz_data['image_mapping'],
+        image_mapping=quiz_data["image_mapping"],
         user_answers=user_answers,
-        already_solved=already_solved
+        already_solved=already_solved,
     )
 
 
-@app.route('/api/quiz/<quiz_id>/reset', methods=['POST'])
+@app.route("/api/quiz/<quiz_id>/reset", methods=["POST"])
 @login_required
 def reset_quiz(quiz_id):
     """Reset a solved quiz to allow it to be solved again."""
@@ -696,10 +702,10 @@ def reset_quiz(quiz_id):
         session_manager.save_session()
 
     # Redirect to the quiz page
-    return redirect(url_for('quiz', quiz_id=quiz_id))
+    return redirect(url_for("quiz", quiz_id=quiz_id))
 
 
-@app.route('/my-quizzes')
+@app.route("/my-quizzes")
 @login_required
 def my_quizzes():
     """Display the user's missions/quizzes."""
@@ -719,35 +725,36 @@ def my_quizzes():
         is_random = quiz_data.is_random
 
         # Format the attempt for display
-        formatted_attempts.append({
-            'id': quiz_id,
-            'title': quiz_data.title,
-            'timestamp': attempt.timestamp,
-            'completed': game_manager.session_manager.is_quiz_solved(quiz_id),
-            'solved': game_manager.session_manager.is_quiz_solved(quiz_id),
-            'exists': True,  # We now store all quiz data, so it always exists
-            'is_random': is_random,
-            'user_answers': attempt.user_answers,
-            'quiz_data': quiz_data.to_dict(),  # Include the full quiz data
-            'image_mapping': quiz_data.image_mapping  # Include the image mapping directly
-        })
+        formatted_attempts.append(
+            {
+                "id": quiz_id,
+                "title": quiz_data.title,
+                "timestamp": attempt.timestamp,
+                "completed": game_manager.session_manager.is_quiz_solved(quiz_id),
+                "solved": game_manager.session_manager.is_quiz_solved(quiz_id),
+                "exists": True,  # We now store all quiz data, so it always exists
+                "is_random": is_random,
+                "user_answers": attempt.user_answers,
+                "quiz_data": quiz_data.to_dict(),  # Include the full quiz data
+                "image_mapping": quiz_data.image_mapping,  # Include the image mapping directly
+            }
+        )
 
     # Sort attempts by timestamp (newest first)
-    formatted_attempts.sort(key=lambda x: x['timestamp'], reverse=True)
+    formatted_attempts.sort(key=lambda x: x["timestamp"], reverse=True)
 
     # Calculate statistics
     stats = {
-        'total_attempts': len(formatted_attempts),
-        'total_solved': len(game_manager.session_manager.solved_quizzes)
+        "total_attempts": len(formatted_attempts),
+        "total_solved": len(game_manager.session_manager.solved_quizzes),
     }
 
-    return render_template('my_quizzes.html',
-                           attempts=formatted_attempts,
-                           stats=stats,
-                           user_name=user_name)
+    return render_template(
+        "my_quizzes.html", attempts=formatted_attempts, stats=stats, user_name=user_name
+    )
 
 
-@app.route('/forget-quiz', methods=['POST'])
+@app.route("/forget-quiz", methods=["POST"])
 @login_required
 def forget_quiz():
     """Remove a quiz attempt from the user's history."""
@@ -755,8 +762,8 @@ def forget_quiz():
     game_manager = create_game_manager()
 
     # Get the timestamp from the form
-    timestamp = request.form.get('timestamp')
-    quiz_id = request.form.get('quiz_id')
+    timestamp = request.form.get("timestamp")
+    quiz_id = request.form.get("quiz_id")
 
     if timestamp:
         # Remove the quiz attempt by timestamp
@@ -773,10 +780,10 @@ def forget_quiz():
         game_manager.session_manager.save_session()
 
     # Redirect back to my quizzes page
-    return redirect(url_for('my_quizzes'))
+    return redirect(url_for("my_quizzes"))
 
 
-@app.route('/reset-progress', methods=['POST'])
+@app.route("/reset-progress", methods=["POST"])
 @login_required
 def reset_progress():
     """Reset all user progress, including solved quizzes and attempts."""
@@ -785,18 +792,18 @@ def reset_progress():
     game_manager.reset()
     game_manager.save_session()
 
-    return redirect(url_for('profile'))
+    return redirect(url_for("profile"))
 
 
-@app.route('/adventure/complete', methods=['POST'])
+@app.route("/adventure/complete", methods=["POST"])
 @login_required
 def complete_adventure():
     """
     Complete an adventure and award XP.
     """
     data = request.json
-    difficulty = data.get('difficulty', 1)
-    caught_pokemon = data.get('caught_pokemon', [])
+    difficulty = data.get("difficulty", 1)
+    caught_pokemon = data.get("caught_pokemon", [])
 
     # Get game manager
     game_manager = create_game_manager()
@@ -812,44 +819,47 @@ def complete_adventure():
     # Get updated level info
     level_info = game_manager.get_player_level_info()
 
-    return jsonify({
-        'success': True,
-        'xp_gained': rewards['xp_reward'],
-        'pokemon_counts': pokemon_counts,
-        'leveled_up': rewards['leveled_up'],
-        'level_info': level_info
-    })
+    return jsonify(
+        {
+            "success": True,
+            "xp_gained": rewards["xp_reward"],
+            "pokemon_counts": pokemon_counts,
+            "leveled_up": rewards["leveled_up"],
+            "level_info": level_info,
+        }
+    )
 
 
 # -----------------------------------------------------------------------------
 # Authentication Routes
 # -----------------------------------------------------------------------------
 
-@app.route('/login')
+
+@app.route("/login")
 def login():
     """
     Display the login page.
-    
+
     If the user is already authenticated, redirect to the home page.
-    
+
     Returns:
         Rendered login template or redirect to home page
     """
     # If user is already authenticated in session, redirect to home page
     if AuthManager.is_authenticated():
         app.logger.info("User already authenticated in session, redirecting to index")
-        return redirect(url_for('index'))
+        return redirect(url_for("index"))
 
-    return render_template('login.html')
+    return render_template("login.html")
 
 
-@app.route('/auth_callback', methods=['POST'])
+@app.route("/auth_callback", methods=["POST"])
 def auth_callback():
     """
     Handle Firebase authentication callback.
-    
+
     Processes both regular Firebase authentication and anonymous (guest) logins.
-    
+
     Returns:
         JSON response with success status and redirect URL
     """
@@ -857,38 +867,36 @@ def auth_callback():
         # Get the ID token from the request
         data = request.get_json(silent=True)
         if not data:
-            return jsonify({'success': False, 'error': 'No data provided'}), 400
+            return jsonify({"success": False, "error": "No data provided"}), 400
 
-        id_token = data.get('id_token')
+        id_token = data.get("id_token")
 
         if not id_token:
-            return jsonify({'success': False, 'error': 'No ID token provided'}), 400
+            return jsonify({"success": False, "error": "No ID token provided"}), 400
 
         try:
             # Verify the ID token with Firebase Admin SDK
             decoded_token = get_auth_client().verify_id_token(id_token)
-            uid = decoded_token['uid']
-            sign_in_provider = decoded_token.get('firebase', {}).get(
-                'sign_in_provider'
-            )
-            is_guest = sign_in_provider == 'anonymous'
+            uid = decoded_token["uid"]
+            sign_in_provider = decoded_token.get("firebase", {}).get("sign_in_provider")
+            is_guest = sign_in_provider == "anonymous"
 
             # Create a session for the user
-            session['user_id'] = uid
+            session["user_id"] = uid
 
             if is_guest:
                 # Handle guest login
-                session['auth_type'] = 'guest'
-                session['authenticated'] = True
-                session['is_guest'] = True
+                session["auth_type"] = "guest"
+                session["authenticated"] = True
+                session["is_guest"] = True
                 # Redirect to name input page for guests
-                redirect_url = url_for('name_input')
-                return jsonify({'success': True, 'redirect': redirect_url})
+                redirect_url = url_for("name_input")
+                return jsonify({"success": True, "redirect": redirect_url})
             else:
                 # Regular user login
-                session['auth_type'] = 'google'
-                session['authenticated'] = True
-                session['is_guest'] = False
+                session["auth_type"] = "google"
+                session["authenticated"] = True
+                session["is_guest"] = False
 
                 # Check if user exists in the database
                 session_manager = create_session_manager()
@@ -896,83 +904,85 @@ def auth_callback():
 
                 if user_name:
                     # Existing user, redirect to home page
-                    redirect_url = url_for('index')
-                    return jsonify({'success': True, 'redirect': redirect_url})
+                    redirect_url = url_for("index")
+                    return jsonify({"success": True, "redirect": redirect_url})
                 else:
                     # New user, redirect to profile setup
-                    redirect_url = url_for('name_input')
-                    return jsonify({'success': True, 'redirect': redirect_url})
+                    redirect_url = url_for("name_input")
+                    return jsonify({"success": True, "redirect": redirect_url})
 
         except Exception:
             app.logger.warning("Firebase ID token verification failed")
-            return jsonify({
-                'success': False,
-                'error': 'Token verification failed',
-            }), 401
+            return jsonify(
+                {
+                    "success": False,
+                    "error": "Token verification failed",
+                }
+            ), 401
 
     except Exception:
         app.logger.exception("Unexpected authentication callback failure")
-        return jsonify({'success': False, 'error': 'Server error'}), 500
+        return jsonify({"success": False, "error": "Server error"}), 500
 
 
-@app.route('/name')
+@app.route("/name")
 @login_required
 def name_input():
     """
     Display the name input page.
-    
+
     Returns:
         Rendered name input page template
     """
     # Get the current name if it exists
     current_name = create_session_manager().get_user_name()
 
-    return render_template('name_input.html', current_name=current_name)
+    return render_template("name_input.html", current_name=current_name)
 
 
-@app.route('/save-name', methods=['POST'])
+@app.route("/save-name", methods=["POST"])
 @login_required
 def save_name():
     """
     Save the user's Pokemon-style name.
-    
+
     Returns:
         Redirect to home page or name input page with error
     """
     try:
         # Get the trainer name from the form
-        trainer_name = request.form.get('trainer_name', '').strip()
+        trainer_name = request.form.get("trainer_name", "").strip()
 
         # Validate the trainer name
         if not trainer_name:
-            return render_template('name_input.html', error='Please enter a name')
+            return render_template("name_input.html", error="Please enter a name")
 
         if len(trainer_name) > 20:
-            return render_template('name_input.html', error='Name must be 20 characters or less')
+            return render_template("name_input.html", error="Name must be 20 characters or less")
 
         # Save the trainer name
         session_manager = create_session_manager()
         session_manager.set_user_name(trainer_name)
 
         # Redirect to home page
-        return redirect(url_for('index'))
+        return redirect(url_for("index"))
     except Exception as e:
         app.logger.error(f"Error in save_name: {e}")
-        return render_template('name_input.html', error=f'An error occurred: {str(e)}')
+        return render_template("name_input.html", error=f"An error occurred: {e!s}")
 
 
-@app.route('/logout')
+@app.route("/logout")
 def logout():
     """
     Log out the current user.
-    
+
     Returns:
         Redirect to login page with a script to sign out from Firebase
     """
     AuthManager.logout()
 
     # Create a response that includes a script to sign out from Firebase
-    response = make_response(render_template('logout.html'))
+    response = make_response(render_template("logout.html"))
 
     return response
 
@@ -982,47 +992,42 @@ def logout():
 def inject_auth_status():
     """
     Add authentication status and CSRF token to all templates.
-    
+
     Returns:
         Dictionary with is_authenticated value and csrf_token function
     """
     from flask_wtf.csrf import generate_csrf
-    return {
-        'is_authenticated': AuthManager.is_authenticated(),
-        'csrf_token': generate_csrf
-    }
+
+    return {"is_authenticated": AuthManager.is_authenticated(), "csrf_token": generate_csrf}
 
 
 # -----------------------------------------------------------------------------
 # Error Handlers
 # -----------------------------------------------------------------------------
 
+
 @app.errorhandler(404)
 def page_not_found(e):
     """Handle 404 errors."""
-    return render_template('error.html',
-                           error_code=404,
-                           error_message="Page not found"), 404
+    return render_template("error.html", error_code=404, error_message="Page not found"), 404
 
 
 @app.errorhandler(500)
 def server_error(e):
     """Handle 500 errors."""
-    return render_template('error.html',
-                           error_code=500,
-                           error_message="Server error"), 500
+    return render_template("error.html", error_code=500, error_message="Server error"), 500
 
 
-@app.route('/api/dev/quiz/<quiz_id>/answers', methods=['GET'])
+@app.route("/api/dev/quiz/<quiz_id>/answers", methods=["GET"])
 @login_required
 def dev_get_quiz_answers(quiz_id):
     """
     Development-only endpoint to get the correct answers for a quiz.
     This endpoint is only available in development mode.
-    
+
     Args:
         quiz_id: The ID of the quiz to get answers for
-        
+
     Returns:
         JSON with the correct answers
     """
@@ -1037,21 +1042,21 @@ def dev_get_quiz_answers(quiz_id):
 
     # If not found in session, try to get from game config (for regular quizzes)
     if not quiz_data:
-        if not quiz_id.startswith('random_'):
+        if not quiz_id.startswith("random_"):
             # Regular quiz - get from game config
             quiz_state = game_manager.get_quiz_state(quiz_id)
             if quiz_state:
                 # Convert to unified format
-                quiz = quiz_state['quiz']
+                quiz = quiz_state["quiz"]
                 quiz_data = {
-                    'quiz_id': quiz_id,
-                    'title': quiz.title,
-                    'description': quiz.description,
-                    'equations': quiz.equations,
-                    'solution': quiz.answer.values,
-                    'image_mapping': quiz_state['image_mapping'],
-                    'next_quiz_id': quiz.next_quiz_id,
-                    'is_random': False
+                    "quiz_id": quiz_id,
+                    "title": quiz.title,
+                    "description": quiz.description,
+                    "equations": quiz.equations,
+                    "solution": quiz.answer.values,
+                    "image_mapping": quiz_state["image_mapping"],
+                    "next_quiz_id": quiz.next_quiz_id,
+                    "is_random": False,
                 }
             else:
                 return jsonify({"error": "Quiz not found"}), 404
@@ -1060,7 +1065,4 @@ def dev_get_quiz_answers(quiz_id):
             return jsonify({"error": "Quiz not found"}), 404
 
     # Return the correct answers
-    return jsonify({
-        "quiz_id": quiz_id,
-        "answers": quiz_data['solution']
-    })
+    return jsonify({"quiz_id": quiz_id, "answers": quiz_data["solution"]})

--- a/src/app/auth/__init__.py
+++ b/src/app/auth/__init__.py
@@ -1,3 +1,3 @@
 """
 Authentication module for PokeMath.
-""" 
+"""

--- a/src/app/auth/auth.py
+++ b/src/app/auth/auth.py
@@ -6,9 +6,10 @@ including Google sign-in and guest user functionality.
 """
 
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any
 
 from flask import current_app, redirect, request, session, url_for
 from flask_wtf.csrf import generate_csrf
@@ -19,111 +20,110 @@ from ..firebase.firebase_init import get_auth_client
 class AuthManager:
     """
     Manages user authentication and session data.
-    
+
     Features:
     - Google authentication using Firebase
     - Guest user authentication
     - Guest account persistence using cookies (30 days)
     - Session management
     """
-    
+
     # Cookie name for storing guest ID
-    GUEST_COOKIE_NAME = 'pokemath_guest_id'
+    GUEST_COOKIE_NAME = "pokemath_guest_id"
     # Cookie expiration in days
     GUEST_COOKIE_EXPIRY = 30
-    
+
     @staticmethod
     def create_guest_user() -> str:
         """
         Create a guest user with a unique ID or reuse an existing guest ID from cookies.
-        
+
         Returns:
             str: The guest user ID
         """
         # Check if there's an existing guest ID in cookies
         existing_guest_id = request.cookies.get(AuthManager.GUEST_COOKIE_NAME)
-        
-        if existing_guest_id and existing_guest_id.startswith('guest_'):
+
+        if existing_guest_id and existing_guest_id.startswith("guest_"):
             # Reuse the existing guest ID
             guest_id = existing_guest_id
         else:
             # Generate a new guest ID
             guest_id = f"guest_{uuid.uuid4()}"
-        
+
         # Store in session
-        session['user_id'] = guest_id
-        session['auth_type'] = 'guest'
-        session['authenticated'] = True
-        session['display_name'] = None
-        
+        session["user_id"] = guest_id
+        session["auth_type"] = "guest"
+        session["authenticated"] = True
+        session["display_name"] = None
+
         # The cookie will be set in the response
         return guest_id
-    
+
     @staticmethod
     def set_guest_cookie(response) -> None:
         """
         Set a persistent cookie with the guest ID.
-        
+
         Args:
             response: Flask response object
         """
-        if session.get('auth_type') == 'guest' and session.get('user_id'):
+        if session.get("auth_type") == "guest" and session.get("user_id"):
             # Calculate expiry time in seconds (days * 24 hours * 60 minutes * 60 seconds)
             max_age = AuthManager.GUEST_COOKIE_EXPIRY * 24 * 60 * 60
-            
+
             # Set the cookie
             response.set_cookie(
                 AuthManager.GUEST_COOKIE_NAME,
-                session['user_id'],
+                session["user_id"],
                 max_age=max_age,
                 httponly=True,
-                samesite='Lax',
-                secure=current_app.config.get('SESSION_COOKIE_SECURE', False),
+                samesite="Lax",
+                secure=current_app.config.get("SESSION_COOKIE_SECURE", False),
             )
 
-    
     @staticmethod
     def is_authenticated() -> bool:
-        return session.get('authenticated', False)
-    
+        return session.get("authenticated", False)
+
     @staticmethod
     def is_guest() -> bool:
-        return session.get('auth_type') == 'guest'
-    
+        return session.get("auth_type") == "guest"
+
     @staticmethod
-    def get_user_id() -> Optional[str]:
-        return session.get('user_id')
-    
+    def get_user_id() -> str | None:
+        return session.get("user_id")
+
     @staticmethod
     def logout() -> None:
         """
         Log the user out by clearing the session.
         """
         # Keep some session data like CSRF token
-        csrf_token = session.get('csrf_token')
-        
+        csrf_token = session.get("csrf_token")
+
         # Remember if this was a guest account
-        was_guest = session.get('auth_type') == 'guest'
-        session.get('user_id') if was_guest else None
-        
+        was_guest = session.get("auth_type") == "guest"
+        session.get("user_id") if was_guest else None
+
         # Clear the session
         session.clear()
-        
+
         # Restore CSRF token if it existed
         if csrf_token:
-            session['csrf_token'] = csrf_token
-            
+            session["csrf_token"] = csrf_token
+
         # Ensure CSRF token is preserved for Flask-WTF
         generate_csrf()
-    
+
     @staticmethod
-    def verify_google_token(id_token: str) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    def verify_google_token(id_token: str) -> tuple[bool, dict[str, Any] | None]:
         """
         Verify a Google ID token and extract user information.
-        
+
         Args:
             id_token: The Google ID token to verify
-            
+
         Returns:
             Tuple of (success, user_data)
             - success: True if verification succeeded, False otherwise
@@ -132,63 +132,65 @@ class AuthManager:
         try:
             # Verify the ID token
             decoded_token = get_auth_client().verify_id_token(id_token)
-            
+
             # Extract user information
             user_data = {
-                'user_id': decoded_token['uid'],
-                'email': decoded_token.get('email'),
-                'name': decoded_token.get('name'),
-                'picture': decoded_token.get('picture')
+                "user_id": decoded_token["uid"],
+                "email": decoded_token.get("email"),
+                "name": decoded_token.get("name"),
+                "picture": decoded_token.get("picture"),
             }
-            
+
             return True, user_data
         except Exception as e:
             print(f"Token verification error: {e}")
             return False, None
-    
+
     @staticmethod
     def login_with_google(id_token: str) -> bool:
         """
         Log in a user with a Google ID token.
-        
+
         Args:
             id_token: The Google ID token to verify
-            
+
         Returns:
             True if login succeeded, False otherwise
         """
         success, user_data = AuthManager.verify_google_token(id_token)
-        
+
         if success and user_data:
             # Set session data
-            session['user_id'] = user_data['user_id']
-            session['auth_type'] = 'google'
-            session['authenticated'] = True
-            session['email'] = user_data.get('email')
+            session["user_id"] = user_data["user_id"]
+            session["auth_type"] = "google"
+            session["authenticated"] = True
+            session["email"] = user_data.get("email")
             # Store Google name separately instead of as display_name
             # This allows users to choose their own game display name
-            session['google_name'] = user_data.get('name')
-            session['picture'] = user_data.get('picture')
-            session['login_time'] = datetime.now().isoformat()
-            
+            session["google_name"] = user_data.get("name")
+            session["picture"] = user_data.get("picture")
+            session["login_time"] = datetime.now().isoformat()
+
             return True
-        
+
         return False
-    
+
     @staticmethod
     def login_required(f: Callable) -> Callable:
         """
         Decorator to require login for routes.
-        
+
         Args:
             f: The view function to decorate
-            
+
         Returns:
             The decorated function
         """
+
         @wraps(f)
         def decorated_function(*args, **kwargs):
             if not AuthManager.is_authenticated():
-                return redirect(url_for('login'))
+                return redirect(url_for("login"))
             return f(*args, **kwargs)
+
         return decorated_function

--- a/src/app/equations/equation_cli.py
+++ b/src/app/equations/equation_cli.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 import sys
-from typing import Any, Dict, List
+from typing import Any
 
 from src.app.equations.equations_generator_v2 import (
     DynamicQuizV2,
@@ -12,18 +12,18 @@ from src.app.equations.equations_generator_v2 import (
 )
 
 
-def load_difficulty_configs(json_path: str) -> List[Dict[str, Any]]:
+def load_difficulty_configs(json_path: str) -> list[dict[str, Any]]:
     """
     Load difficulty configurations from a JSON file.
-    
+
     Args:
         json_path: Path to the JSON file containing difficulty configurations
-        
+
     Returns:
         List of difficulty configurations
     """
     try:
-        with open(json_path, 'r') as f:
+        with open(json_path) as f:
             return json.load(f)
     except FileNotFoundError:
         print(f"Error: Could not find difficulty configuration file at {json_path}")
@@ -43,10 +43,10 @@ def format_value(value: Any) -> str:
     return str(value)
 
 
-def print_equation(quiz: DynamicQuizV2, index: int = 1, config_type: str = None) -> None:
+def print_equation(quiz: DynamicQuizV2, index: int = 1, config_type: str | None = None) -> None:
     """
     Print a formatted equation and its solution.
-    
+
     Args:
         quiz: The generated quiz containing equations and solutions
         index: The equation number (for display purposes)
@@ -56,34 +56,36 @@ def print_equation(quiz: DynamicQuizV2, index: int = 1, config_type: str = None)
     for _i, eq in enumerate(quiz.equations):
         # Clean up the equation formatting for better display
         formatted_eq = eq.formatted
-        
+
         # Replace decimal values with cleaner format
-        if '.' in formatted_eq:
+        if "." in formatted_eq:
             # Find all decimal numbers and format them
-            decimal_pattern = r'(\d+\.\d+)'
-            formatted_eq = re.sub(decimal_pattern, lambda m: format_value(float(m.group(1))), formatted_eq)
-        
+            decimal_pattern = r"(\d+\.\d+)"
+            formatted_eq = re.sub(
+                decimal_pattern, lambda m: format_value(float(m.group(1))), formatted_eq
+            )
+
         print(f"  {formatted_eq}")
-    
+
     print("\nSolution:")
     for var, value in quiz.solution.human_readable.items():
         print(f"  {var} = {format_value(value)}")
     print()
 
 
-def generate_equations(difficulty_configs: List[Dict[str, Any]], 
-                      difficulty_id: str = None, 
-                      count: int = 4) -> None:
+def generate_equations(
+    difficulty_configs: list[dict[str, Any]], difficulty_id: str | None = None, count: int = 4
+) -> None:
     """
     Generate equations based on difficulty configurations.
-    
+
     Args:
         difficulty_configs: List of difficulty configurations
         difficulty_id: ID of the specific difficulty to generate (None for all)
         count: Number of equations to generate for each difficulty
     """
     generator = EquationsGeneratorV2()
-    
+
     # Filter configurations based on difficulty_id if provided
     if difficulty_id:
         configs = [config for config in difficulty_configs if config["id"] == difficulty_id]
@@ -95,52 +97,64 @@ def generate_equations(difficulty_configs: List[Dict[str, Any]],
             sys.exit(1)
     else:
         configs = difficulty_configs
-    
+
     # Generate equations for each selected difficulty
     for config in configs:
         print(f"\n=== {config['name']} (Difficulty Level: {config['difficulty']}) ===")
-        
+
         # Get the configuration type
         config_type = config["params"].get("type", "")
-        
+
         for i in range(count):
             # Use the v2 generator's generate_equations method with the params
             quiz = generator.generate_equations(config["params"])
             print_equation(quiz, i + 1, config_type)
-        
+
         print("-" * 60)
 
 
 def main():
     """Main entry point for the CLI application."""
     # Define the path to the difficulty configurations
-    json_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 
-                            "data", "equation_difficulties_v2.json")
-    
+    json_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "data",
+        "equation_difficulties_v2.json",
+    )
+
     # Set up argument parser
-    parser = argparse.ArgumentParser(description="Generate math equations based on difficulty levels")
-    parser.add_argument("-d", "--difficulty", 
-                        help="Generate equations for a specific difficulty ID")
-    parser.add_argument("-c", "--count", type=int, default=4,
-                        help="Number of equations to generate for each difficulty (default: 4)")
-    parser.add_argument("-l", "--list", action="store_true",
-                        help="List all available difficulty levels")
-    
+    parser = argparse.ArgumentParser(
+        description="Generate math equations based on difficulty levels"
+    )
+    parser.add_argument(
+        "-d", "--difficulty", help="Generate equations for a specific difficulty ID"
+    )
+    parser.add_argument(
+        "-c",
+        "--count",
+        type=int,
+        default=4,
+        help="Number of equations to generate for each difficulty (default: 4)",
+    )
+    parser.add_argument(
+        "-l", "--list", action="store_true", help="List all available difficulty levels"
+    )
+
     args = parser.parse_args()
-    
+
     # Load difficulty configurations
     difficulty_configs = load_difficulty_configs(json_path)
-    
+
     # List available difficulties if requested
     if args.list:
         print("Available difficulty levels:")
         for config in difficulty_configs:
             print(f"  - {config['id']}: {config['name']} (Level {config['difficulty']})")
         sys.exit(0)
-    
+
     # Generate equations
     generate_equations(difficulty_configs, args.difficulty, args.count)
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/src/app/equations/equations_generator_v2.py
+++ b/src/app/equations/equations_generator_v2.py
@@ -17,13 +17,9 @@ import random
 from fractions import Fraction
 from typing import (
     Any,
-    Dict,
-    List,
     Literal,
     NamedTuple,
-    Optional,
     TypedDict,
-    Union,
 )
 
 import sympy as sp
@@ -32,105 +28,115 @@ import sympy as sp
 # TypedDict definitions for configuration parameters
 class EquationPatternConfig(TypedDict, total=False):
     """Configuration for a specific equation pattern."""
+
     pattern: str  # Pattern with placeholders like {var1}, {var2}, {const}
-    values: Dict[str, Union[int, float]]  # Optional fixed values for variables or constants
+    values: dict[str, int | float]  # Optional fixed values for variables or constants
 
 
 class BasicMathConfig(TypedDict, total=False):
     """Configuration for basic math equations."""
+
     type: Literal["basic_math"]  # Must be "basic_math"
-    operations: List[str]  # Allowed operations ["+", "-", "*", "/"]
+    operations: list[str]  # Allowed operations ["+", "-", "*", "/"]
     max_value: int  # Maximum value for constants
     allow_decimals: bool  # Whether to allow decimal values
     elements: int  # Number of elements in the equation (e.g., 2 for x = a + b)
-    random_seed: Optional[int]  # Optional random seed for reproducibility
+    random_seed: int | None  # Optional random seed for reproducibility
 
 
 class SimpleQuizConfig(TypedDict, total=False):
     """Configuration for simple quiz equations."""
+
     type: Literal["simple_quiz"]  # Must be "simple_quiz"
     num_unknowns: int  # Number of unknown variables
     max_value: int  # Maximum value for constants
-    random_seed: Optional[int]  # Optional random seed for reproducibility
+    random_seed: int | None  # Optional random seed for reproducibility
 
 
 class GradeSchoolConfig(TypedDict, total=False):
     """Configuration for grade school equations."""
+
     type: Literal["grade_school"]  # Must be "grade_school"
     num_unknowns: int  # Number of unknown variables
-    operations: List[str]  # Allowed operations ["+", "-", "*", "/"] 
+    operations: list[str]  # Allowed operations ["+", "-", "*", "/"]
     max_value: int  # Maximum value for constants
     allow_decimals: bool  # Whether to allow decimal values
-    random_seed: Optional[int]  # Optional random seed for reproducibility
+    random_seed: int | None  # Optional random seed for reproducibility
 
 
 # Union type for all configuration types
-EquationConfig = Union[BasicMathConfig, SimpleQuizConfig, GradeSchoolConfig]
+EquationConfig = BasicMathConfig | SimpleQuizConfig | GradeSchoolConfig
 
 
 class EquationV2(NamedTuple):
     """Representation of a generated equation for V2."""
+
     symbolic: Any  # SymPy equation
     formatted: str  # Human-readable format
 
 
 class DynamicQuizSolutionV2(NamedTuple):
     """Representation of variable solutions for V2."""
-    symbolic: Dict[Any, Union[int, float, Fraction]]  # SymPy symbols to values
-    human_readable: Dict[str, Union[int, float, Fraction]]  # Variable names to values
+
+    symbolic: dict[Any, int | float | Fraction]  # SymPy symbols to values
+    human_readable: dict[str, int | float | Fraction]  # Variable names to values
 
 
 class DynamicQuizV2(NamedTuple):
     """Complete quiz with equations and solutions for V2."""
-    equations: List[EquationV2]
+
+    equations: list[EquationV2]
     solution: DynamicQuizSolutionV2
 
 
 class EquationsGeneratorV2:
     """
     The V2 implementation of the equation generator.
-    
+
     This class provides methods to generate different types of equation sets:
     - Basic math equations (one unknown, left side only)
     - Simple quiz equations (multiple unknowns, integer solutions)
     - Grade school equations (configurable unknowns and operations)
-    
+
     All generation methods ensure that the resulting equations have exactly one solution.
     """
 
     def __init__(self):
         """Initialize the equation generator with default values."""
-        self.variables = list('xyzwvu')
-        self.operations = ['+', '-', '*', '/']
+        self.variables = list("xyzwvu")
+        self.operations = ["+", "-", "*", "/"]
 
-    def generate_basic_math(self, operations: Optional[List[str]] = None,
-                            max_value: int = 30,
-                            allow_decimals: bool = False,
-                            elements: int = 2,
-                            random_seed: Optional[int] = None) -> DynamicQuizV2:
+    def generate_basic_math(
+        self,
+        operations: list[str] | None = None,
+        max_value: int = 30,
+        allow_decimals: bool = False,
+        elements: int = 2,
+        random_seed: int | None = None,
+    ) -> DynamicQuizV2:
         """
         Generate a basic math equation with one unknown on the left side.
-        
+
         Args:
             operations: List of allowed operations, defaults to ['+', '-']
             max_value: Maximum value for constants, defaults to 30
             allow_decimals: Whether to allow decimal values, defaults to False
             elements: Number of elements in the equation, defaults to 2 (x = a + b)
             random_seed: Optional random seed for reproducibility
-            
+
         Returns:
             DynamicQuizV2: The generated quiz with equations and solution
         """
         # Set default operations if not provided
         if operations is None:
-            operations = ['+', '-']
+            operations = ["+", "-"]
 
         # Set random seed if provided
         if random_seed is not None:
             random.seed(random_seed)
 
         # Create the variable symbol
-        x = sp.Symbol('x')
+        x = sp.Symbol("x")
 
         # Build the right side of the equation
         right_side_expr = None
@@ -157,16 +163,16 @@ class EquationsGeneratorV2:
                 operand_value = random.randint(1, max_value)
 
             # Apply the operation to the right side expression
-            if operation == '+':
+            if operation == "+":
                 right_side_expr += operand_value
                 right_side_formatted += f" + {operand_value}"
-            elif operation == '-':
+            elif operation == "-":
                 right_side_expr -= operand_value
                 right_side_formatted += f" - {operand_value}"
-            elif operation == '*':
+            elif operation == "*":
                 right_side_expr *= operand_value
                 right_side_formatted += f" * {operand_value}"
-            elif operation == '/':
+            elif operation == "/":
                 # Ensure we don't divide by zero and result is clean
                 if operand_value == 0:
                     operand_value = 1
@@ -174,7 +180,9 @@ class EquationsGeneratorV2:
                 # If decimals are not allowed, ensure division results in an integer
                 if not allow_decimals:
                     # Find a divisor that divides the current expression evenly
-                    divisors = [i for i in range(1, min(11, max_value + 1)) if right_side_expr % i == 0]
+                    divisors = [
+                        i for i in range(1, min(11, max_value + 1)) if right_side_expr % i == 0
+                    ]
                     if not divisors:
                         # If no clean divisors, switch to multiplication
                         right_side_expr *= operand_value
@@ -201,28 +209,26 @@ class EquationsGeneratorV2:
         return DynamicQuizV2(
             equations=[EquationV2(equation, formatted_equation)],
             solution=DynamicQuizSolutionV2(
-                symbolic=symbolic_solution,
-                human_readable=human_readable_solution
-            )
+                symbolic=symbolic_solution, human_readable=human_readable_solution
+            ),
         )
 
-    def generate_simple_quiz(self,
-                             num_unknowns: int = 2,
-                             max_value: int = 20,
-                             random_seed: Optional[int] = None) -> DynamicQuizV2:
+    def generate_simple_quiz(
+        self, num_unknowns: int = 2, max_value: int = 20, random_seed: int | None = None
+    ) -> DynamicQuizV2:
         """
         Generate a simple quiz with multiple unknowns and integer solutions.
-        
+
         Simple quiz equations always use + and - operations only.
         Same symbol can be repeated in the same equation.
         Solution is always an integer.
         Number of equations equals number of unknowns.
-        
+
         Args:
             num_unknowns: Number of unknown variables, defaults to 2
             max_value: Maximum value for constants, defaults to 20
             random_seed: Optional random seed for reproducibility
-            
+
         Returns:
             DynamicQuizV2: The generated quiz with equations and solution
         """
@@ -235,7 +241,7 @@ class EquationsGeneratorV2:
 
         # Generate random integer solutions for each variable
         solution_values = {}
-        for i, var in enumerate(var_symbols):
+        for var in var_symbols:
             solution_values[var] = random.randint(1, max_value)
 
         # Create human-readable solution dictionary
@@ -270,9 +276,9 @@ class EquationsGeneratorV2:
                 other_var_name = str(other_var)
 
                 # Choose an operation (+ or -)
-                operation = random.choice(['+', '-'])
+                operation = random.choice(["+", "-"])
 
-                if operation == '+':
+                if operation == "+":
                     left_side += other_var
                     formatted_left += f" + {other_var_name}"
                     right_side_value += solution_values[other_var]
@@ -306,42 +312,45 @@ class EquationsGeneratorV2:
                 return self.generate_simple_quiz(num_unknowns, max_value, random_seed)
 
         # Create equation objects
-        equation_objects = [EquationV2(eq, fmt) for eq, fmt in zip(equations, formatted_equations, strict=False)]
+        equation_objects = [
+            EquationV2(eq, fmt) for eq, fmt in zip(equations, formatted_equations, strict=False)
+        ]
 
         # Create the quiz
         return DynamicQuizV2(
             equations=equation_objects,
             solution=DynamicQuizSolutionV2(
-                symbolic=solution_values,
-                human_readable=human_readable_solution
-            )
+                symbolic=solution_values, human_readable=human_readable_solution
+            ),
         )
 
-    def generate_grade_school(self,
-                              num_unknowns: int = 2,
-                              operations: Optional[List[str]] = None,
-                              max_value: int = 30,
-                              allow_decimals: bool = False,
-                              random_seed: Optional[int] = None) -> DynamicQuizV2:
+    def generate_grade_school(
+        self,
+        num_unknowns: int = 2,
+        operations: list[str] | None = None,
+        max_value: int = 30,
+        allow_decimals: bool = False,
+        random_seed: int | None = None,
+    ) -> DynamicQuizV2:
         """
         Generate grade school equations with multiple unknowns.
-        
+
         Grade school equations can use multiple unknowns and various operations.
         Number of equations equals number of unknowns.
-        
+
         Args:
             num_unknowns: Number of unknown variables, defaults to 2
             operations: List of allowed operations, defaults to ['+', '-']
             max_value: Maximum value for constants, defaults to 30
             allow_decimals: Whether to allow decimal values, defaults to False
             random_seed: Optional random seed for reproducibility
-            
+
         Returns:
             DynamicQuizV2: The generated quiz with equations and solution
         """
         # Set default operations if not provided
         if operations is None:
-            operations = ['+', '-']
+            operations = ["+", "-"]
 
         # Set random seed if provided
         if random_seed is not None:
@@ -398,7 +407,7 @@ class EquationsGeneratorV2:
                         else:
                             left_side += coef * var
                             # Format based on allowed operations
-                            if '*' in operations:
+                            if "*" in operations:
                                 formatted_left += f"{coef}*{var}"
                             else:
                                 # If multiplication is not allowed, use addition instead
@@ -409,39 +418,39 @@ class EquationsGeneratorV2:
                         # For subsequent terms, choose an operation
                         operation = random.choice(operations)
 
-                        if operation == '+':
+                        if operation == "+":
                             if coef == 1:
                                 left_side += var
                                 formatted_left += f" + {var}"
                             else:
                                 left_side += coef * var
                                 # Format based on allowed operations
-                                if '*' in operations:
+                                if "*" in operations:
                                     formatted_left += f" + {coef}*{var}"
                                 else:
                                     # If multiplication is not allowed, use addition instead
                                     for _ in range(coef):
                                         formatted_left += f" + {var}"
-                        elif operation == '-':
+                        elif operation == "-":
                             if coef == 1:
                                 left_side -= var
                                 formatted_left += f" - {var}"
                             else:
                                 left_side -= coef * var
                                 # Format based on allowed operations
-                                if '*' in operations:
+                                if "*" in operations:
                                     formatted_left += f" - {coef}*{var}"
                                 else:
                                     # If multiplication is not allowed, use subtraction instead
                                     for _ in range(coef):
                                         formatted_left += f" - {var}"
-                        elif operation == '*' and '*' in operations:
+                        elif operation == "*" and "*" in operations:
                             # Multiplication is only applied to the previous term
                             # This is a simplification to avoid complex expressions
                             if j > 0:
                                 left_side *= coef
                                 formatted_left = f"({formatted_left}) * {coef}"
-                        elif operation == '/' and '/' in operations:
+                        elif operation == "/" and "/" in operations:
                             # Division is only applied to the previous term
                             # This is a simplification to avoid complex expressions
                             if j > 0 and coef != 0:
@@ -451,9 +460,9 @@ class EquationsGeneratorV2:
                 # Sometimes add a constant term
                 if random.random() > 0.5:
                     const = random.randint(1, max_value // 3)
-                    operation = random.choice(['+', '-'])
+                    operation = random.choice(["+", "-"])
 
-                    if operation == '+':
+                    if operation == "+":
                         left_side += const
                         formatted_left += f" + {const}"
                     else:
@@ -464,7 +473,7 @@ class EquationsGeneratorV2:
                 right_side_value = left_side.subs(solution_values)
 
                 # Ensure the right side value is within max_value if it's a constant
-                if isinstance(right_side_value, (int, float)) and abs(right_side_value) > max_value:
+                if isinstance(right_side_value, int | float) and abs(right_side_value) > max_value:
                     # Create a new equation with a smaller right side
                     if right_side_value > 0:
                         new_right_side = random.randint(1, max_value)
@@ -524,7 +533,7 @@ class EquationsGeneratorV2:
                 left_side = coef * var
 
                 # Format based on allowed operations
-                if '*' in operations:
+                if "*" in operations:
                     if coef == 1:
                         formatted_left = f"{var}"
                     else:
@@ -549,7 +558,7 @@ class EquationsGeneratorV2:
                 right_side_value = left_side.subs(solution_values)
 
                 # Ensure the right side value is within max_value
-                if isinstance(right_side_value, (int, float)) and abs(right_side_value) > max_value:
+                if isinstance(right_side_value, int | float) and abs(right_side_value) > max_value:
                     # Create a new equation with a smaller right side
                     if right_side_value > 0:
                         new_right_side = random.randint(1, max_value)
@@ -574,24 +583,25 @@ class EquationsGeneratorV2:
                 formatted_equations.append(formatted_equation)
 
         # Create equation objects
-        equation_objects = [EquationV2(eq, fmt) for eq, fmt in zip(equations, formatted_equations, strict=False)]
+        equation_objects = [
+            EquationV2(eq, fmt) for eq, fmt in zip(equations, formatted_equations, strict=False)
+        ]
 
         # Create the quiz
         return DynamicQuizV2(
             equations=equation_objects,
             solution=DynamicQuizSolutionV2(
-                symbolic=solution_values,
-                human_readable=human_readable_solution
-            )
+                symbolic=solution_values, human_readable=human_readable_solution
+            ),
         )
 
     def generate_equations(self, config: EquationConfig) -> DynamicQuizV2:
         """
         Generate equations based on a configuration dictionary.
-        
+
         This is the main entry point for the V2 generator, allowing for a unified
         configuration-based approach to generating all types of equations.
-        
+
         Args:
             config: A strongly-typed configuration dictionary with the following structure:
                 For BasicMathConfig:
@@ -603,7 +613,7 @@ class EquationsGeneratorV2:
                     "elements": 2,  # Optional
                     "random_seed": 12345  # Optional
                 }
-                
+
                 For SimpleQuizConfig:
                 {
                     "type": "simple_quiz",
@@ -611,7 +621,7 @@ class EquationsGeneratorV2:
                     "max_value": 20,  # Optional
                     "random_seed": 12345  # Optional
                 }
-                
+
                 For GradeSchoolConfig:
                 {
                     "type": "grade_school",
@@ -621,10 +631,10 @@ class EquationsGeneratorV2:
                     "allow_decimals": False,  # Optional
                     "random_seed": 12345  # Optional
                 }
-                
+
         Returns:
             DynamicQuizV2: The generated quiz with equations and solution
-            
+
         Raises:
             ValueError: If the configuration is invalid
         """
@@ -646,13 +656,13 @@ class EquationsGeneratorV2:
                 max_value=config.get("max_value", 30),
                 allow_decimals=config.get("allow_decimals", False),
                 elements=config.get("elements", 2),
-                random_seed=random_seed
+                random_seed=random_seed,
             )
         elif equation_type == "simple_quiz":
             return self.generate_simple_quiz(
                 num_unknowns=config.get("num_unknowns", 2),
                 max_value=config.get("max_value", 20),
-                random_seed=random_seed
+                random_seed=random_seed,
             )
         elif equation_type == "grade_school":
             return self.generate_grade_school(
@@ -660,7 +670,7 @@ class EquationsGeneratorV2:
                 operations=config.get("operations", ["+", "-"]),
                 max_value=config.get("max_value", 30),
                 allow_decimals=config.get("allow_decimals", False),
-                random_seed=random_seed
+                random_seed=random_seed,
             )
         else:
             raise ValueError(f"Unknown equation type: {equation_type}")

--- a/src/app/firebase/__init__.py
+++ b/src/app/firebase/__init__.py
@@ -1,3 +1,3 @@
 """
 Firebase services for PokeMath.
-""" 
+"""

--- a/src/app/firebase/firebase_init.py
+++ b/src/app/firebase/firebase_init.py
@@ -1,7 +1,7 @@
 """
 Firebase initialization module for PokeMath.
 
-This module centralizes the initialization of Firebase Admin SDK 
+This module centralizes the initialization of Firebase Admin SDK
 to ensure consistent access to Firestore and Auth services.
 """
 
@@ -12,23 +12,24 @@ from firebase_admin import auth, firestore
 _firestore_client = None
 _auth_client = None
 
+
 def initialize_firebase():
     """
     Initialize Firebase Admin SDK.
-    
+
     Use Application Default Credentials in every environment. Cloud Run obtains
     short-lived credentials from its service account; local development uses
     credentials created by ``gcloud auth application-default login``.
-    
+
     Returns:
         Tuple of (firestore_client, auth_instance)
     """
     global _firestore_client, _auth_client
-    
+
     # Return existing clients if already initialized
     if _firestore_client is not None and _auth_client is not None:
         return _firestore_client, _auth_client
-    
+
     # Check if Firebase is already initialized
     if firebase_admin._apps:
         firebase_admin._apps[0]
@@ -42,17 +43,18 @@ def initialize_firebase():
                 "Credentials. For local development, run "
                 "`gcloud auth application-default login`."
             ) from e
-    
+
     # Get clients
     _firestore_client = firestore.client()
     _auth_client = auth
-    
+
     return _firestore_client, _auth_client
+
 
 def get_firestore_client():
     """
     Get the Firestore client.
-    
+
     Returns:
         Firestore client instance
     """
@@ -61,10 +63,11 @@ def get_firestore_client():
         initialize_firebase()
     return _firestore_client
 
+
 def get_auth_client():
     """
     Get the Auth client.
-    
+
     Returns:
         Auth client instance
     """

--- a/src/app/game/__init__.py
+++ b/src/app/game/__init__.py
@@ -1,8 +1,19 @@
 """
 Game logic and state management.
 """
+
 from src.app.game.game_config import load_equation_difficulties, load_game_config
 from src.app.game.game_manager import GameManager
 from src.app.game.pokemon_selector import PokemonSelector
 from src.app.game.quiz_engine import check_quiz_answers, generate_random_quiz_data
 from src.app.game.session_manager import SessionManager
+
+__all__ = [
+    "GameManager",
+    "PokemonSelector",
+    "SessionManager",
+    "check_quiz_answers",
+    "generate_random_quiz_data",
+    "load_equation_difficulties",
+    "load_game_config",
+]

--- a/src/app/game/game_config.py
+++ b/src/app/game/game_config.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass
@@ -10,66 +10,72 @@ class Pokemon:
     image_path: str
     tier: int = 1  # Default to tier 1 (common)
 
+
 @dataclass
 class QuizAnswer:
-    values: Dict[str, int]
+    values: dict[str, int]
+
 
 @dataclass
 class Quiz:
     id: str
     title: str
     description: str
-    equations: List[str]
+    equations: list[str]
     answer: QuizAnswer
     section_id: str
     section_title: str
     display_number: int
-    next_quiz_id: Optional[str] = None
+    next_quiz_id: str | None = None
+
 
 @dataclass
 class Section:
     id: str
     title: str
     description: str
-    quizzes: List[Quiz]
+    quizzes: list[Quiz]
+
 
 @dataclass
 class GameConfig:
-    pokemons: Dict[str, Pokemon]
-    sections: List[Section]
-    quizzes_by_id: Dict[str, Quiz]
+    pokemons: dict[str, Pokemon]
+    sections: list[Section]
+    quizzes_by_id: dict[str, Quiz]
 
-def load_pokemon_config(data_file: Path) -> Dict[str, Pokemon]:
+
+def load_pokemon_config(data_file: Path) -> dict[str, Pokemon]:
     with open(data_file) as f:
         raw_data = json.load(f)
 
     pokemons = {}
-    
+
     # Get Pokemon data and tier assignments
-    pokemon_data = raw_data['pokemons']
-    tier_data = raw_data['tiers']
-    
+    pokemon_data = raw_data["pokemons"]
+    tier_data = raw_data["tiers"]
+
     # First create all Pokemon objects with default tier
     for name, data in pokemon_data.items():
         pokemons[name] = Pokemon(
             name=name,
-            image_path=data.get('image_path', ''),
-            tier=1  # Default tier
+            image_path=data.get("image_path", ""),
+            tier=1,  # Default tier
         )
-    
+
     # Then assign tiers based on the tiers mapping
     for tier_str, pokemon_names in tier_data.items():
         tier = int(tier_str)
         for pokemon_name in pokemon_names:
             if pokemon_name in pokemons:
                 pokemons[pokemon_name].tier = tier
-    
+
     return pokemons
+
 
 def load_game_config(data_file: Path, pokemon_file: Path) -> GameConfig:
     with open(data_file) as f:
         raw_data = json.load(f)
-    
+
     # Load Pokemon data from separate file
     pokemons = load_pokemon_config(pokemon_file)
 
@@ -77,31 +83,31 @@ def load_game_config(data_file: Path, pokemon_file: Path) -> GameConfig:
     sections = []
     quizzes_by_id = {}
 
-    for section_data in raw_data['sections']:
+    for section_data in raw_data["sections"]:
         section_quizzes = []
-        for idx, quiz_data in enumerate(section_data['quizzes'], 1):
+        for idx, quiz_data in enumerate(section_data["quizzes"], 1):
             # Create quiz object with answer
-            answer = QuizAnswer(values=quiz_data['answer'])
-            
+            answer = QuizAnswer(values=quiz_data["answer"])
+
             quiz = Quiz(
-                id=quiz_data['id'],
-                title=quiz_data['title'],
-                description=quiz_data['description'],
-                equations=quiz_data['equations'],
+                id=quiz_data["id"],
+                title=quiz_data["title"],
+                description=quiz_data["description"],
+                equations=quiz_data["equations"],
                 answer=answer,
-                section_id=section_data['id'],
-                section_title=section_data['title'],
-                display_number=idx
+                section_id=section_data["id"],
+                section_title=section_data["title"],
+                display_number=idx,
             )
             section_quizzes.append(quiz)
             quizzes_by_id[quiz.id] = quiz
 
         # Create section object
         section = Section(
-            id=section_data['id'],
-            title=section_data['title'],
-            description=section_data['description'],
-            quizzes=section_quizzes
+            id=section_data["id"],
+            title=section_data["title"],
+            description=section_data["description"],
+            quizzes=section_quizzes,
         )
         sections.append(section)
 
@@ -115,14 +121,10 @@ def load_game_config(data_file: Path, pokemon_file: Path) -> GameConfig:
             elif section_idx < len(sections) - 1 and sections[section_idx + 1].quizzes:
                 quiz.next_quiz_id = sections[section_idx + 1].quizzes[0].id
 
-    return GameConfig(
-        pokemons=pokemons,
-        sections=sections,
-        quizzes_by_id=quizzes_by_id
-    )
+    return GameConfig(pokemons=pokemons, sections=sections, quizzes_by_id=quizzes_by_id)
 
 
-def load_equation_difficulties(file_path: Path) -> List[Dict[str, Any]]:
+def load_equation_difficulties(file_path: Path) -> list[dict[str, Any]]:
     with open(file_path) as f:
         difficulties = json.load(f)
     return difficulties

--- a/src/app/game/game_manager.py
+++ b/src/app/game/game_manager.py
@@ -1,5 +1,3 @@
-from typing import Dict, Optional, Set
-
 from src.app.game.game_config import GameConfig
 from src.app.game.progression_manager import ProgressionManager
 from src.app.game.quiz_engine import check_quiz_answers, get_display_variables
@@ -9,7 +7,7 @@ from src.app.game.session_manager import SessionManager
 class GameManager:
     """
     Orchestrates game state and configuration.
-    
+
     Manages quiz sessions, user progress, and coordinates between
     the game configuration and session storage.
     """
@@ -19,22 +17,20 @@ class GameManager:
         self.session_manager = session_manager
 
     @classmethod
-    def initialize_from_session(cls, quiz_data: GameConfig,
-                                session_manager: Optional[SessionManager] = None) -> 'GameManager':
+    def initialize_from_session(
+        cls, quiz_data: GameConfig, session_manager: SessionManager | None = None
+    ) -> "GameManager":
         """Create a new GameManager with optional session manager."""
         if session_manager is None:
             session_manager = SessionManager.load_from_storage()
 
-        return cls(
-            game_config=quiz_data,
-            session_manager=session_manager
-        )
+        return cls(game_config=quiz_data, session_manager=session_manager)
 
     def save_session(self):
         """Save the current session state."""
         self.session_manager.save_session()
 
-    def get_quiz_state(self, quiz_id: str) -> Optional[Dict]:
+    def get_quiz_state(self, quiz_id: str) -> dict | None:
         """Get the state of a specific quiz."""
         quiz = self.game_config.quizzes_by_id.get(quiz_id)
         if not quiz:
@@ -44,22 +40,19 @@ class GameManager:
         display_vars = get_display_variables(self.game_config, {})
 
         return {
-            'quiz': quiz,
-            'image_mapping': display_vars,
-            'is_solved': self.session_manager.is_quiz_solved(quiz_id)
+            "quiz": quiz,
+            "image_mapping": display_vars,
+            "is_solved": self.session_manager.is_quiz_solved(quiz_id),
         }
 
-    def check_answers(self, quiz_id: str, user_answers: Dict[str, int]):
+    def check_answers(self, quiz_id: str, user_answers: dict[str, int]):
         """Check the user's answers for a quiz."""
         quiz = self.game_config.quizzes_by_id.get(quiz_id)
         if not quiz:
-            return {'error': 'Quiz not found'}
+            return {"error": "Quiz not found"}
 
         # Use the quiz_engine module to check answers
-        all_correct, correct_answers, all_answered = check_quiz_answers(
-            quiz,
-            user_answers
-        )
+        all_correct, correct_answers, all_answered = check_quiz_answers(quiz, user_answers)
 
         # Only mark as solved if all answers are correct and all questions were answered
         if all_correct and all_answered:
@@ -70,12 +63,12 @@ class GameManager:
         total_count = len(correct_answers)
 
         return {
-            'correct': all_correct and all_answered,
-            'correct_answers': correct_answers,
-            'next_quiz_id': quiz.next_quiz_id,
-            'all_answered': all_answered,
-            'correct_count': correct_count,
-            'total_count': total_count
+            "correct": all_correct and all_answered,
+            "correct_answers": correct_answers,
+            "next_quiz_id": quiz.next_quiz_id,
+            "all_answered": all_answered,
+            "correct_count": correct_count,
+            "total_count": total_count,
         }
 
     def reset(self):
@@ -83,24 +76,24 @@ class GameManager:
         self.session_manager.reset()
 
     @property
-    def solved_quizzes(self) -> Set[str]:
+    def solved_quizzes(self) -> set[str]:
         """Get the set of solved quizzes."""
         return self.session_manager.solved_quizzes
 
     def add_xp_and_handle_level_up(self, xp_amount: int) -> bool:
         """
         Add XP to the player and handle level-ups.
-        
+
         Args:
             xp_amount: Amount of XP to add
-            
+
         Returns:
             True if player leveled up, False otherwise
         """
         # Get current level and XP from session
         current_state = self.session_manager.get_level_and_xp()
-        current_level = current_state['level']
-        current_xp = current_state['xp']
+        current_level = current_state["level"]
+        current_xp = current_state["xp"]
 
         # Add XP to current amount
         current_xp += xp_amount
@@ -109,40 +102,35 @@ class GameManager:
         result = ProgressionManager.process_level_up(current_level, current_xp)
 
         # Update session with new level and XP
-        self.session_manager.update_level_and_xp(result['level'], result['xp'])
+        self.session_manager.update_level_and_xp(result["level"], result["xp"])
 
-        return result['leveled_up']
+        return result["leveled_up"]
 
     def calculate_adventure_rewards(self, caught_pokemon, difficulty):
         """
         Calculate rewards for completing an adventure.
-        
+
         Args:
             caught_pokemon: List of caught Pokémon IDs
             difficulty: Adventure difficulty level
-            
+
         Returns:
             Dictionary with XP reward and whether player leveled up
         """
         # Calculate XP reward using ProgressionManager
         xp_reward = ProgressionManager.calculate_xp_reward(
-            caught_pokemon,
-            difficulty,
-            self.game_config
+            caught_pokemon, difficulty, self.game_config
         )
 
         # Add XP and handle level-up
         leveled_up = self.add_xp_and_handle_level_up(xp_reward)
 
-        return {
-            'xp_reward': xp_reward,
-            'leveled_up': leveled_up
-        }
+        return {"xp_reward": xp_reward, "leveled_up": leveled_up}
 
     def get_player_level_info(self):
         """
         Get player level information.
-        
+
         Returns:
             Dictionary with level, current XP, and XP needed for next level
         """
@@ -150,7 +138,4 @@ class GameManager:
         current_state = self.session_manager.get_level_and_xp()
 
         # Use ProgressionManager to get level info
-        return ProgressionManager.get_level_info(
-            current_state['level'],
-            current_state['xp']
-        )
+        return ProgressionManager.get_level_info(current_state["level"], current_state["xp"])

--- a/src/app/game/models.py
+++ b/src/app/game/models.py
@@ -5,116 +5,118 @@ This module contains dataclasses for strongly typed quiz data structures.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 
 @dataclass
 class QuizData:
     """Strongly typed model for quiz data."""
+
     quiz_id: str
     title: str
-    equations: List[str]
-    solution: Dict[str, str]  # Variable name -> solution value
-    image_mapping: Dict[str, str]  # Variable name -> Pokemon image path
+    equations: list[str]
+    solution: dict[str, str]  # Variable name -> solution value
+    image_mapping: dict[str, str]  # Variable name -> Pokemon image path
     description: str = ""
-    next_quiz_id: Optional[str] = None
-    difficulty: Optional[Dict[str, Any]] = None
+    next_quiz_id: str | None = None
+    difficulty: dict[str, Any] | None = None
     is_random: bool = False
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
-            'quiz_id': self.quiz_id,
-            'title': self.title,
-            'equations': self.equations,
-            'solution': self.solution,
-            'image_mapping': self.image_mapping,
-            'description': self.description,
-            'next_quiz_id': self.next_quiz_id,
-            'difficulty': self.difficulty,
-            'is_random': self.is_random
+            "quiz_id": self.quiz_id,
+            "title": self.title,
+            "equations": self.equations,
+            "solution": self.solution,
+            "image_mapping": self.image_mapping,
+            "description": self.description,
+            "next_quiz_id": self.next_quiz_id,
+            "difficulty": self.difficulty,
+            "is_random": self.is_random,
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'QuizData':
+    def from_dict(cls, data: dict[str, Any]) -> "QuizData":
         """Create a QuizData instance from a dictionary."""
         return cls(
-            quiz_id=data.get('quiz_id', ''),
-            title=data.get('title', ''),
-            equations=data.get('equations', []),
-            solution=data.get('solution', {}),
-            image_mapping=data.get('image_mapping', {}),
-            description=data.get('description', ''),
-            next_quiz_id=data.get('next_quiz_id'),
-            difficulty=data.get('difficulty'),
-            is_random=data.get('is_random', False)
+            quiz_id=data.get("quiz_id", ""),
+            title=data.get("title", ""),
+            equations=data.get("equations", []),
+            solution=data.get("solution", {}),
+            image_mapping=data.get("image_mapping", {}),
+            description=data.get("description", ""),
+            next_quiz_id=data.get("next_quiz_id"),
+            difficulty=data.get("difficulty"),
+            is_random=data.get("is_random", False),
         )
 
 
 @dataclass
 class QuizAttempt:
     """Strongly typed model for a quiz attempt."""
+
     quiz_id: str
     quiz_data: QuizData
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
-    user_answers: Dict[str, int] = field(default_factory=dict)
+    user_answers: dict[str, int] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
-            'quiz_id': self.quiz_id,
-            'quiz_data': self.quiz_data.to_dict(),
-            'timestamp': self.timestamp,
-            'user_answers': self.user_answers
+            "quiz_id": self.quiz_id,
+            "quiz_data": self.quiz_data.to_dict(),
+            "timestamp": self.timestamp,
+            "user_answers": self.user_answers,
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'QuizAttempt':
+    def from_dict(cls, data: dict[str, Any]) -> "QuizAttempt":
         """Create a QuizAttempt instance from a dictionary."""
-        quiz_data = QuizData.from_dict(data.get('quiz_data', {}))
+        quiz_data = QuizData.from_dict(data.get("quiz_data", {}))
         return cls(
-            quiz_id=data.get('quiz_id', ''),
+            quiz_id=data.get("quiz_id", ""),
             quiz_data=quiz_data,
-            timestamp=data.get('timestamp', datetime.now().isoformat()),
-            user_answers=data.get('user_answers', {})
+            timestamp=data.get("timestamp", datetime.now().isoformat()),
+            user_answers=data.get("user_answers", {}),
         )
 
 
 @dataclass
 class SessionState:
     """Strongly typed model for session state."""
-    solved_quizzes: Set[str] = field(default_factory=set)
-    quiz_attempts: List[QuizAttempt] = field(default_factory=list)
-    user_name: Optional[str] = None
+
+    solved_quizzes: set[str] = field(default_factory=set)
+    quiz_attempts: list[QuizAttempt] = field(default_factory=list)
+    user_name: str | None = None
     level: int = 1
     xp: int = 0
-    caught_pokemon: Dict[str, int] = field(default_factory=dict)  # Pokemon ID -> count
+    caught_pokemon: dict[str, int] = field(default_factory=dict)  # Pokemon ID -> count
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for serialization."""
         return {
-            'solved_quizzes': list(self.solved_quizzes),
-            'quiz_attempts': [attempt.to_dict() for attempt in self.quiz_attempts],
-            'user_name': self.user_name,
-            'level': self.level,
-            'xp': self.xp,
-            'caught_pokemon': self.caught_pokemon
+            "solved_quizzes": list(self.solved_quizzes),
+            "quiz_attempts": [attempt.to_dict() for attempt in self.quiz_attempts],
+            "user_name": self.user_name,
+            "level": self.level,
+            "xp": self.xp,
+            "caught_pokemon": self.caught_pokemon,
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'SessionState':
+    def from_dict(cls, data: dict[str, Any]) -> "SessionState":
         """Create a SessionState instance from a dictionary."""
         quiz_attempts = [
-            QuizAttempt.from_dict(attempt_data)
-            for attempt_data in data.get('quiz_attempts', [])
+            QuizAttempt.from_dict(attempt_data) for attempt_data in data.get("quiz_attempts", [])
         ]
         return cls(
-            solved_quizzes=set(data.get('solved_quizzes', [])),
+            solved_quizzes=set(data.get("solved_quizzes", [])),
             quiz_attempts=quiz_attempts,
-            user_name=data.get('user_name'),
-            level=data.get('level', 1),
-            xp=data.get('xp', 0),
-            caught_pokemon=data.get('caught_pokemon', {})
+            user_name=data.get("user_name"),
+            level=data.get("level", 1),
+            xp=data.get("xp", 0),
+            caught_pokemon=data.get("caught_pokemon", {}),
         )
 
     def reset(self):
@@ -126,4 +128,4 @@ class SessionState:
         self.level = 1
         self.xp = 0
         # Clear caught Pokémon
-        self.caught_pokemon.clear() 
+        self.caught_pokemon.clear()

--- a/src/app/game/pokemon_selector.py
+++ b/src/app/game/pokemon_selector.py
@@ -1,8 +1,9 @@
 """
 Module for selecting Pokémon based on player level and adventure difficulty.
 """
+
 import random
-from typing import Any, Dict, List
+from typing import Any
 
 from src.app.game.progression_config import (
     DIFFICULTY_MULTIPLIER,
@@ -16,9 +17,9 @@ class PokemonSelector:
     """
     Handles the selection of Pokémon based on player level and adventure difficulty.
     """
-    
+
     @staticmethod
-    def get_eligible_tiers(player_level: int) -> List[int]:
+    def get_eligible_tiers(player_level: int) -> list[int]:
         """
         Determine which Pokémon tiers are unlocked based on player level.
         """
@@ -27,84 +28,84 @@ class PokemonSelector:
             if player_level >= unlock_level:
                 eligible_tiers.append(tier)
         return sorted(eligible_tiers)
-    
+
     @staticmethod
     def calculate_adjusted_weight(tier: int, difficulty: int, player_level: int = 1) -> float:
         """
         Calculate the adjusted weight for a Pokémon based on its tier, adventure difficulty, and player level.
-        
+
         Args:
             tier: Pokémon tier (1-5)
             difficulty: Adventure difficulty (1-7)
             player_level: Player level (default: 1)
-            
+
         Returns:
             Adjusted weight for random selection
         """
-        # Apply the formula: W_T × (1 + (D-1)/6 × (T-1) + L/50 × (T-1))
+        # Apply the formula: W_T x (1 + (D-1)/6 x (T-1) + L/50 x (T-1))
         # Where:
         # - W_T is the base weight for tier T
         # - D is the difficulty level (1-7)
         # - L is the player level
         # - T is the Pokémon tier (1-5)
-        
+
         # For tier 1, always return the base weight regardless of difficulty or level
         if tier == 1:
             return TIER_BASE_WEIGHTS[tier]
-            
+
         # For other tiers, apply the formula
-        return TIER_BASE_WEIGHTS[tier] * (1 + (difficulty - 1) * DIFFICULTY_MULTIPLIER * (tier - 1) +
-                                          (player_level - 10) * LEVEL_MULTIPLIER * (tier - 1))
-    
+        return TIER_BASE_WEIGHTS[tier] * (
+            1
+            + (difficulty - 1) * DIFFICULTY_MULTIPLIER * (tier - 1)
+            + (player_level - 10) * LEVEL_MULTIPLIER * (tier - 1)
+        )
+
     @classmethod
-    def select_pokemon(cls, pokemons: Dict[str, Any], player_level: int, difficulty: int, count: int = 1) -> List[str]:
+    def select_pokemon(
+        cls, pokemons: dict[str, Any], player_level: int, difficulty: int, count: int = 1
+    ) -> list[str]:
         """
         Select Pokémon based on player level and adventure difficulty.
         Pokemon will be only select from eligible tiers, based on level
         From all eligible pokemon they will be selected based on their weight - on lower level and with lower difficulty
         common pokemon are more likely, with higher level and higher difficulty more rare pokemon start to appear
-        
+
         Args:
             pokemons: Dictionary of all available Pokémon
             player_level: Current player level
             difficulty: Adventure difficulty (1-7)
             count: Number of Pokémon to select (default: 1)
-            
+
         Returns:
             List of selected Pokémon IDs
         """
         eligible_tiers = cls.get_eligible_tiers(player_level)
-        
+
         # Filter Pokémon by eligible tiers
         eligible_pokemon = {
-            name: pokemon for name, pokemon in pokemons.items()
-            if pokemon.tier in eligible_tiers
+            name: pokemon for name, pokemon in pokemons.items() if pokemon.tier in eligible_tiers
         }
-        
+
         if not eligible_pokemon:
             return []
-        
+
         # Calculate weights for each eligible Pokémon
         weights = {
             name: cls.calculate_adjusted_weight(pokemon.tier, difficulty, player_level)
             for name, pokemon in eligible_pokemon.items()
         }
-        
+
         # Select Pokémon based on weights
         pokemon_names = list(weights.keys())
         pokemon_weights = [weights[name] for name in pokemon_names]
-        
+
         # Ensure we don't try to select more than available
         count = min(count, len(pokemon_names))
-        
+
         if count == 0:
             return []
-        
+
         # Select Pokémon
-        selected = random.choices(
-            population=pokemon_names,
-            weights=pokemon_weights,
-            k=count
-        )
-        
-        return selected 
+        selected = random.choices(population=pokemon_names, weights=pokemon_weights, k=count)
+
+        return selected

--- a/src/app/game/progression_config.py
+++ b/src/app/game/progression_config.py
@@ -11,35 +11,35 @@ BASE_XP = 150
 
 # XP rewards per Pokémon tier
 TIER_XP_REWARDS = {
-    1: 50,   # Common
+    1: 50,  # Common
     2: 100,  # Uncommon
     3: 200,  # Rare
     4: 400,  # Very Rare
-    5: 800   # Legendary
+    5: 800,  # Legendary
 }
 
 # Base weights for Pokémon selection by tier
 TIER_BASE_WEIGHTS = {
     1: 1,  # Common
-    2: 2,   # Uncommon
-    3: 3,   # Rare
-    4: 5,   # Very Rare
-    5: 8     # Legendary
+    2: 2,  # Uncommon
+    3: 3,  # Rare
+    4: 5,  # Very Rare
+    5: 8,  # Legendary
 }
 
 # Difficulty multiplier for tier weights
-DIFFICULTY_MULTIPLIER = 1/5
+DIFFICULTY_MULTIPLIER = 1 / 5
 
 # Level multiplier for tier weights
-LEVEL_MULTIPLIER = 1/4
+LEVEL_MULTIPLIER = 1 / 4
 
 # Tier unlock levels
 TIER_UNLOCK_LEVELS = {
-    1: 1,    # Available from start
-    2: 11,   # Unlock at level 11
-    3: 21,   # Unlock at level 21
-    4: 31,   # Unlock at level 31
-    5: 41    # Unlock at level 41
+    1: 1,  # Available from start
+    2: 11,  # Unlock at level 11
+    3: 21,  # Unlock at level 21
+    4: 31,  # Unlock at level 31
+    5: 41,  # Unlock at level 41
 }
 
 # Bonus XP per difficulty level

--- a/src/app/game/progression_manager.py
+++ b/src/app/game/progression_manager.py
@@ -3,7 +3,7 @@ Progression management module.
 Handles XP calculations, level-up logic, and progression-related functionality.
 """
 
-from typing import Any, Dict, List
+from typing import Any
 
 from src.app.game.progression_config import (
     BASE_XP,
@@ -20,15 +20,15 @@ class ProgressionManager:
     """
 
     @staticmethod
-    def calculate_xp_reward(caught_pokemon: List[str], difficulty: int, game_config) -> int:
+    def calculate_xp_reward(caught_pokemon: list[str], difficulty: int, game_config) -> int:
         """
         Calculate XP reward for catching Pokémon and completing an adventure.
-        
+
         Args:
             caught_pokemon: List of caught Pokémon IDs
             difficulty: Adventure difficulty (1-7)
             game_config: GameConfig object containing Pokémon data
-            
+
         Returns:
             Total XP reward
         """
@@ -37,7 +37,9 @@ class ProgressionManager:
         for pokemon_id in caught_pokemon:
             if pokemon_id in game_config.pokemons:
                 tier = game_config.pokemons[pokemon_id].tier
-                pokemon_xp += TIER_XP_REWARDS.get(tier, TIER_XP_REWARDS[1])  # Default to tier 1 reward
+                pokemon_xp += TIER_XP_REWARDS.get(
+                    tier, TIER_XP_REWARDS[1]
+                )  # Default to tier 1 reward
 
         # Add bonus XP for adventure completion
         bonus_xp = DIFFICULTY_BONUS_XP * difficulty
@@ -48,24 +50,24 @@ class ProgressionManager:
     def calculate_xp_needed(level: int) -> int:
         """
         Calculate XP needed for the next level.
-        
+
         Args:
             level: Current player level
-            
+
         Returns:
             XP needed for next level
         """
         return int(BASE_XP * (XP_MULTIPLIER ** (level - 1)))
 
     @classmethod
-    def process_level_up(cls, current_level: int, current_xp: int) -> Dict[str, Any]:
+    def process_level_up(cls, current_level: int, current_xp: int) -> dict[str, Any]:
         """
         Process level-up logic based on current level and XP.
-        
+
         Args:
             current_level: Current player level
             current_xp: Current player XP
-            
+
         Returns:
             Dictionary with updated level, XP, and whether player leveled up
         """
@@ -79,26 +81,18 @@ class ProgressionManager:
             level += 1
             leveled_up = True
 
-        return {
-            'level': level,
-            'xp': xp,
-            'leveled_up': leveled_up
-        }
+        return {"level": level, "xp": xp, "leveled_up": leveled_up}
 
     @classmethod
-    def get_level_info(cls, level: int, xp: int) -> Dict[str, Any]:
+    def get_level_info(cls, level: int, xp: int) -> dict[str, Any]:
         """
         Get player level information.
-        
+
         Args:
             level: Current player level
             xp: Current player XP
-            
+
         Returns:
             Dictionary with level, current XP, and XP needed for next level
         """
-        return {
-            'level': level,
-            'xp': xp,
-            'xp_needed': cls.calculate_xp_needed(level)
-        } 
+        return {"level": level, "xp": xp, "xp_needed": cls.calculate_xp_needed(level)}

--- a/src/app/game/quiz_engine.py
+++ b/src/app/game/quiz_engine.py
@@ -1,28 +1,30 @@
 import uuid
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from src.app.game.game_config import GameConfig, Quiz
 from src.app.game.pokemon_selector import PokemonSelector
 
 
-def check_quiz_answers(quiz: Quiz, user_answers: Dict[str, int]) -> Tuple[bool, Dict[str, bool], bool]:
+def check_quiz_answers(
+    quiz: Quiz, user_answers: dict[str, int]
+) -> tuple[bool, dict[str, bool], bool]:
     """
     Check the user's answers for a quiz.
     This is a pure function that can be tested in isolation.
-    
+
     Args:
         quiz: The quiz to check answers for
         user_answers: Dictionary of variable names to user-provided values
-        
+
     Returns:
         Tuple of (all_correct, correct_answers_dict, all_answered)
     """
     # Map variable names to their actual values
     mapped_answers = {}
-    
+
     # Get all expected answer variables
     expected_vars = set(quiz.answer.values.keys())
-    
+
     # Track which variables were answered
     answered_vars = set()
 
@@ -47,23 +49,21 @@ def check_quiz_answers(quiz: Quiz, user_answers: Dict[str, int]) -> Tuple[bool, 
     return all_correct, correct_answers, all_answered
 
 
-def get_display_variables(game_config: GameConfig,
-                          image_mapping: Dict[str, str] = None) -> Dict[str, str]:
+def get_display_variables(
+    game_config: GameConfig, image_mapping: dict[str, str] | None = None
+) -> dict[str, str]:
     """
     Get display variables for a quiz, including Pokemon image paths.
-    
+
     Args:
         game_config: The game configuration containing Pokemon information
         image_mapping: Optional dictionary mapping variables to image paths
-        
+
     Returns:
         Dictionary mapping variable names to image paths
     """
     # Create display variables dictionary with all Pokemon
-    display_vars = {
-        name: pokemon.image_path
-        for name, pokemon in game_config.pokemons.items()
-    }
+    display_vars = {name: pokemon.image_path for name, pokemon in game_config.pokemons.items()}
 
     # Add any image mappings if provided
     if image_mapping:
@@ -72,44 +72,43 @@ def get_display_variables(game_config: GameConfig,
     return display_vars
 
 
-def generate_random_quiz_data(game_config, difficulty: Dict[str, Any], equation_generator, player_level: int = 1) -> Tuple[str, Dict[str, Any]]:
+def generate_random_quiz_data(
+    game_config, difficulty: dict[str, Any], equation_generator, player_level: int = 1
+) -> tuple[str, dict[str, Any]]:
     """
     Generate random quiz data for the given difficulty and player level.
-    
+
     The function uses PokemonSelector to select appropriate Pokémon based on the player's level
     and the difficulty of the quiz. Higher player levels unlock higher tier Pokémon, and
     higher difficulties increase the probability of selecting higher tier Pokémon.
-    
+
     Args:
         game_config: The game configuration containing Pokemon information
         difficulty: Difficulty configuration with 'name' and 'level' keys
         equation_generator: The equation generator to use
         player_level: Current player level, determines which Pokémon tiers are available
-    
+
     Returns:
         Tuple of (quiz_id, quiz_data)
     """
     # Generate a random equation using the EquationsGeneratorV2
-    quiz = equation_generator.generate_equations(difficulty['params'])
+    quiz = equation_generator.generate_equations(difficulty["params"])
 
     # Create a unique ID for the random quiz
     random_quiz_id = f"random_{uuid.uuid4().hex[:8]}"
 
     # Create Pokemon variable mappings for the random variables
     image_mapping = {}
-    
+
     # Get the number of variables needed for this quiz
     num_variables = len(quiz.solution.human_readable.keys())
-    
+
     # Use PokemonSelector to select appropriate Pokemon based on player level and difficulty
-    difficulty_level = difficulty.get('level', 1)  # Default to 1 if not specified
+    difficulty_level = difficulty.get("level", 1)  # Default to 1 if not specified
     selected_pokemon = PokemonSelector.select_pokemon(
-        game_config.pokemons, 
-        player_level, 
-        difficulty_level, 
-        count=num_variables
+        game_config.pokemons, player_level, difficulty_level, count=num_variables
     )
-    
+
     # Map variables to selected Pokemon
     variables = list(quiz.solution.human_readable.keys())
     for i, pokemon_name in enumerate(selected_pokemon):
@@ -125,13 +124,13 @@ def generate_random_quiz_data(game_config, difficulty: Dict[str, Any], equation_
 
     # Create quiz data structure
     quiz_data = {
-        'quiz_id': random_quiz_id,
-        'title': f"Random {difficulty['name']} Quiz",
-        'equations': formatted_equations,
-        'solution': {var: str(val) for var, val in quiz.solution.human_readable.items()},
-        'difficulty': difficulty,
-        'image_mapping': image_mapping,
-        'description': f"A randomly generated {difficulty['name'].lower()} difficulty quiz."
+        "quiz_id": random_quiz_id,
+        "title": f"Random {difficulty['name']} Quiz",
+        "equations": formatted_equations,
+        "solution": {var: str(val) for var, val in quiz.solution.human_readable.items()},
+        "difficulty": difficulty,
+        "image_mapping": image_mapping,
+        "description": f"A randomly generated {difficulty['name'].lower()} difficulty quiz.",
     }
 
     return random_quiz_id, quiz_data

--- a/src/app/game/session_manager.py
+++ b/src/app/game/session_manager.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 from flask import session as flask_session
 
@@ -15,10 +15,10 @@ class SessionManager:
     Uses a storage implementation to persist data.
     """
 
-    def __init__(self, storage: Optional[UserStorageInterface] = None, user_id: Optional[str] = None):
+    def __init__(self, storage: UserStorageInterface | None = None, user_id: str | None = None):
         """
         Initialize the session manager.
-        
+
         Args:
             storage: Storage implementation. Defaults to FlaskSessionStorage.
             user_id: User ID. If not provided, will be loaded from Flask session
@@ -34,22 +34,20 @@ class SessionManager:
         """
         Get existing user ID from Flask session or create a new one.
         """
-        if 'user_id' not in flask_session:
+        if "user_id" not in flask_session:
             # Create a guest user if no user ID exists
             return AuthManager.create_guest_user()
-        return flask_session['user_id']
+        return flask_session["user_id"]
 
     def _load_state(self):
         """Load state from storage."""
         data = self.storage.load_user_data(self.user_id)
-        if 'session_state' in data:
-            self.state = SessionState.from_dict(data['session_state'])
+        if "session_state" in data:
+            self.state = SessionState.from_dict(data["session_state"])
 
     def _save_state(self):
         """Save state to storage."""
-        self.storage.save_user_data(self.user_id, {
-            'session_state': self.state.to_dict()
-        })
+        self.storage.save_user_data(self.user_id, {"session_state": self.state.to_dict()})
 
     def reset(self):
         """Reset the session state."""
@@ -64,11 +62,11 @@ class SessionManager:
         return quiz_id in self.state.solved_quizzes
 
     @property
-    def solved_quizzes(self) -> Set[str]:
+    def solved_quizzes(self) -> set[str]:
         return self.state.solved_quizzes
 
     @classmethod
-    def load_from_storage(cls, storage: Optional[UserStorageInterface] = None) -> 'SessionManager':
+    def load_from_storage(cls, storage: UserStorageInterface | None = None) -> "SessionManager":
         """
         Create session manager with specified storage and user ID from Flask session
         """
@@ -78,7 +76,7 @@ class SessionManager:
         """
         Save user_id to Flask session and state to storage.
         """
-        flask_session['user_id'] = self.user_id
+        flask_session["user_id"] = self.user_id
         self._save_state()
 
     # User name management methods
@@ -87,22 +85,21 @@ class SessionManager:
         self.state.user_name = name
         self._save_state()
 
-    def get_user_name(self) -> Optional[str]:
+    def get_user_name(self) -> str | None:
         return self.state.user_name
 
     # Quiz attempts methods
 
-    def get_quiz_attempts(self) -> List[QuizAttempt]:
+    def get_quiz_attempts(self) -> list[QuizAttempt]:
         return self.state.quiz_attempts
 
     def remove_quiz_attempt(self, timestamp: str):
         self.state.quiz_attempts = [
-            attempt for attempt in self.state.quiz_attempts
-            if attempt.timestamp != timestamp
+            attempt for attempt in self.state.quiz_attempts if attempt.timestamp != timestamp
         ]
         self._save_state()
 
-    def find_quiz_attempt(self, quiz_id: str) -> Optional[QuizAttempt]:
+    def find_quiz_attempt(self, quiz_id: str) -> QuizAttempt | None:
         for attempt in self.state.quiz_attempts:
             if attempt.quiz_id == quiz_id:
                 return attempt
@@ -110,18 +107,18 @@ class SessionManager:
 
     # Unified quiz data methods
 
-    def save_quiz_data(self, quiz_id: str, quiz_data_dict: Dict[str, Any], is_random: bool = False):
+    def save_quiz_data(self, quiz_id: str, quiz_data_dict: dict[str, Any], is_random: bool = False):
         """
         Save quiz data for both random and regular quizzes.
-        
+
         Args:
             quiz_id: The ID of the quiz
             quiz_data_dict: Complete quiz data including equations, variables, solutions
             is_random: Whether this is a randomly generated quiz
         """
         # Convert dictionary to QuizData object
-        quiz_data_dict['is_random'] = is_random
-        quiz_data_dict['quiz_id'] = quiz_id
+        quiz_data_dict["is_random"] = is_random
+        quiz_data_dict["quiz_id"] = quiz_id
         quiz_data = QuizData.from_dict(quiz_data_dict)
 
         # Find existing attempt for this quiz or create a new one
@@ -133,7 +130,7 @@ class SessionManager:
                 quiz_id=quiz_id,
                 quiz_data=quiz_data,
                 timestamp=datetime.now().isoformat(),
-                user_answers={}
+                user_answers={},
             )
             self.state.quiz_attempts.append(attempt)
         else:
@@ -143,7 +140,7 @@ class SessionManager:
 
         self._save_state()
 
-    def get_quiz_data(self, quiz_id: str) -> Optional[Dict[str, Any]]:
+    def get_quiz_data(self, quiz_id: str) -> dict[str, Any] | None:
         """
         Get quiz data for any quiz by ID.
         """
@@ -153,7 +150,7 @@ class SessionManager:
             return attempt.quiz_data.to_dict()
         return None
 
-    def save_quiz_answers(self, quiz_id: str, user_answers: Dict[str, int]):
+    def save_quiz_answers(self, quiz_id: str, user_answers: dict[str, int]):
         """
         Save user answers for any quiz.
         """
@@ -164,7 +161,7 @@ class SessionManager:
             attempt.timestamp = datetime.now().isoformat()
             self._save_state()
 
-    def get_quiz_answers(self, quiz_id: str) -> Dict[str, int]:
+    def get_quiz_answers(self, quiz_id: str) -> dict[str, int]:
         """
         Get the user's answers for a quiz.
         """
@@ -176,10 +173,10 @@ class SessionManager:
     def catch_pokemon(self, pokemon_id: str) -> int:
         """
         Add a Pokémon to the player's caught list or increment its count.
-        
+
         Args:
             pokemon_id: ID of the Pokémon to catch
-            
+
         Returns:
             The new count for this Pokémon
         """
@@ -190,10 +187,10 @@ class SessionManager:
 
         return new_count
 
-    def get_caught_pokemon(self) -> Dict[str, int]:
+    def get_caught_pokemon(self) -> dict[str, int]:
         """
         Get the dictionary of caught Pokémon IDs and their counts.
-        
+
         Returns:
             Dictionary mapping Pokémon IDs to catch counts
         """
@@ -202,7 +199,7 @@ class SessionManager:
     def update_xp(self, xp_amount: int) -> None:
         """
         Update player's XP by adding the specified amount.
-        
+
         Args:
             xp_amount: Amount of XP to add
         """
@@ -212,7 +209,7 @@ class SessionManager:
     def update_level_and_xp(self, level: int, xp: int) -> None:
         """
         Update player's level and XP directly.
-        
+
         Args:
             level: New player level
             xp: New player XP
@@ -221,14 +218,11 @@ class SessionManager:
         self.state.xp = xp
         self._save_state()
 
-    def get_level_and_xp(self) -> Dict[str, Any]:
+    def get_level_and_xp(self) -> dict[str, Any]:
         """
         Get player's current level and XP.
-        
+
         Returns:
             Dictionary with level and XP
         """
-        return {
-            'level': self.state.level,
-            'xp': self.state.xp
-        }
+        return {"level": self.state.level, "xp": self.state.xp}

--- a/src/app/security/rate_limiter.py
+++ b/src/app/security/rate_limiter.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import math
 import time
 from collections import OrderedDict, deque
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from ipaddress import ip_address
 from threading import Lock
-from typing import Callable, Deque, Iterable, Optional
 
 
 @dataclass(frozen=True)
@@ -48,8 +48,8 @@ class RequestRateLimiter:
         self._max_client_buckets = max_client_buckets
         self._clock = clock
         self._lock = Lock()
-        self._global: dict[str, Deque[float]] = {}
-        self._clients: OrderedDict[tuple[str, str], Deque[float]] = OrderedDict()
+        self._global: dict[str, deque[float]] = {}
+        self._clients: OrderedDict[tuple[str, str], deque[float]] = OrderedDict()
 
     def check(
         self,
@@ -62,7 +62,7 @@ class RequestRateLimiter:
         now = self._clock()
 
         with self._lock:
-            counters: list[tuple[Deque[float], int, int]] = []
+            counters: list[tuple[deque[float], int, int]] = []
             for limit in requested_limits:
                 if limit.global_limit < 1 or limit.client_limit < 1:
                     raise ValueError("rate limits must be positive")
@@ -93,7 +93,7 @@ class RequestRateLimiter:
                 counter.append(now)
             return RateLimitDecision(True)
 
-    def _client_counter(self, scope: str, client_id: str) -> Deque[float]:
+    def _client_counter(self, scope: str, client_id: str) -> deque[float]:
         key = (scope, client_id)
         counter = self._clients.get(key)
         if counter is not None:
@@ -107,15 +107,15 @@ class RequestRateLimiter:
         return counter
 
     @staticmethod
-    def _prune(counter: Deque[float], now: float, window_seconds: int) -> None:
+    def _prune(counter: deque[float], now: float, window_seconds: int) -> None:
         cutoff = now - window_seconds
         while counter and counter[0] <= cutoff:
             counter.popleft()
 
 
 def client_identifier(
-    remote_addr: Optional[str],
-    forwarded_for: Optional[str],
+    remote_addr: str | None,
+    forwarded_for: str | None,
     *,
     trust_forwarded_for: bool,
 ) -> str:
@@ -129,7 +129,7 @@ def client_identifier(
 
     candidates = []
     if trust_forwarded_for and forwarded_for:
-        candidates.extend(part.strip() for part in forwarded_for.split(','))
+        candidates.extend(part.strip() for part in forwarded_for.split(","))
     if remote_addr:
         candidates.append(remote_addr.strip())
 

--- a/src/app/storage/__init__.py
+++ b/src/app/storage/__init__.py
@@ -1,3 +1,3 @@
 """
 Storage implementations for quiz session data.
-""" 
+"""

--- a/src/app/storage/firestore_storage.py
+++ b/src/app/storage/firestore_storage.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from firebase_admin import firestore
 
@@ -8,36 +8,36 @@ from .storage_interface import UserStorageInterface
 
 class FirestoreStorage(UserStorageInterface):
     """Stores user data in Firestore."""
-    
-    def __init__(self, collection_name: str = 'users'):
+
+    def __init__(self, collection_name: str = "users"):
         """
         Initialize Firestore client.
-        
+
         Args:
             collection_name: The name of the collection to store user data in
         """
         self.db = get_firestore_client()
         self.collection_name = collection_name
-        
+
     def _get_user_ref(self, user_id: str):
         """
         Get Firestore reference for a user.
-        
+
         Args:
             user_id: The unique identifier for the user
-            
+
         Returns:
             Firestore document reference for the user
         """
         return self.db.collection(self.collection_name).document(user_id)
-    
-    def load_user_data(self, user_id: str) -> Dict[str, Any]:
+
+    def load_user_data(self, user_id: str) -> dict[str, Any]:
         """
         Load user data from Firestore.
-        
+
         Args:
             user_id: The unique identifier for the user
-            
+
         Returns:
             User data dictionary or empty dict if not found
         """
@@ -50,11 +50,11 @@ class FirestoreStorage(UserStorageInterface):
             # Log the error and return empty dict
             print(f"Error loading user data from Firestore: {e}")
             return {}
-    
-    def save_user_data(self, user_id: str, data: Dict[str, Any]) -> None:
+
+    def save_user_data(self, user_id: str, data: dict[str, Any]) -> None:
         """
         Save user data to Firestore.
-        
+
         Args:
             user_id: The unique identifier for the user
             data: The data to save
@@ -62,19 +62,19 @@ class FirestoreStorage(UserStorageInterface):
         try:
             # Add server timestamp
             data_with_timestamp = dict(data)
-            data_with_timestamp['last_updated'] = firestore.SERVER_TIMESTAMP
+            data_with_timestamp["last_updated"] = firestore.SERVER_TIMESTAMP
             self._get_user_ref(user_id).set(data_with_timestamp, merge=True)
         except Exception as e:
             # Log the error
             print(f"Error saving user data to Firestore: {e}")
-        
+
     def user_exists(self, user_id: str) -> bool:
         """
         Check if user exists in Firestore.
-        
+
         Args:
             user_id: The unique identifier for the user
-            
+
         Returns:
             True if the user exists, False otherwise
         """
@@ -83,4 +83,4 @@ class FirestoreStorage(UserStorageInterface):
         except Exception as e:
             # Log the error and return False
             print(f"Error checking if user exists in Firestore: {e}")
-            return False 
+            return False

--- a/src/app/storage/flask_session_storage.py
+++ b/src/app/storage/flask_session_storage.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from flask import session as flask_session
 
@@ -7,37 +7,37 @@ from .storage_interface import UserStorageInterface
 
 class FlaskSessionStorage(UserStorageInterface):
     """Stores user data in Flask session."""
-    
-    def load_user_data(self, user_id: str) -> Dict[str, Any]:
+
+    def load_user_data(self, user_id: str) -> dict[str, Any]:
         """
         Load data from Flask session.
-        
+
         Args:
             user_id: The unique identifier for the user
-            
+
         Returns:
             The user data from Flask session or an empty dict if not found
         """
-        return flask_session.get('session_state', {})
-    
-    def save_user_data(self, user_id: str, data: Dict[str, Any]) -> None:
+        return flask_session.get("session_state", {})
+
+    def save_user_data(self, user_id: str, data: dict[str, Any]) -> None:
         """
         Save data to Flask session.
-        
+
         Args:
             user_id: The unique identifier for the user (not used for Flask session)
             data: The data to save to Flask session
         """
-        flask_session['session_state'] = data
-        
+        flask_session["session_state"] = data
+
     def user_exists(self, user_id: str) -> bool:
         """
         Check if user data exists in session.
-        
+
         Args:
             user_id: The unique identifier for the user (not used for Flask session)
-            
+
         Returns:
             True if the session state exists, False otherwise
         """
-        return 'session_state' in flask_session 
+        return "session_state" in flask_session

--- a/src/app/storage/session_factory.py
+++ b/src/app/storage/session_factory.py
@@ -6,7 +6,7 @@ from src.app.storage.flask_session_storage import FlaskSessionStorage
 def create_session_manager(use_firestore: bool = True) -> SessionManager:
     """
     Factory function to create a SessionManager with the appropriate storage.
-    
+
     Handles creation of either Firestore or Flask session storage based on the parameter.
     """
     if use_firestore:
@@ -15,6 +15,6 @@ def create_session_manager(use_firestore: bool = True) -> SessionManager:
     else:
         # Create Flask session storage
         storage = FlaskSessionStorage()
-        
+
     # Create and return a SessionManager with the specified storage
     return SessionManager.load_from_storage(storage=storage)

--- a/src/app/storage/storage_interface.py
+++ b/src/app/storage/storage_interface.py
@@ -1,39 +1,39 @@
-from typing import Any, Dict
+from typing import Any
 
 
 class UserStorageInterface:
     """Interface for user data storage implementations."""
-    
-    def load_user_data(self, user_id: str) -> Dict[str, Any]:
+
+    def load_user_data(self, user_id: str) -> dict[str, Any]:
         """
         Load data for a specific user_id.
-        
+
         Args:
             user_id: The unique identifier for the user
-            
+
         Returns:
             A dictionary containing the user's data
         """
         raise NotImplementedError
-    
-    def save_user_data(self, user_id: str, data: Dict[str, Any]) -> None:
+
+    def save_user_data(self, user_id: str, data: dict[str, Any]) -> None:
         """
         Save data for a specific user_id.
-        
+
         Args:
             user_id: The unique identifier for the user
             data: The data to save
         """
         raise NotImplementedError
-        
+
     def user_exists(self, user_id: str) -> bool:
         """
         Check if a user exists in storage.
-        
+
         Args:
             user_id: The unique identifier for the user
-            
+
         Returns:
             True if the user exists, False otherwise
         """
-        raise NotImplementedError 
+        raise NotImplementedError

--- a/src/app/view_models.py
+++ b/src/app/view_models.py
@@ -7,24 +7,25 @@ These classes provide a strongly-typed interface between the application and vie
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass
 class QuizViewModel:
     """View model for quiz templates."""
+
     # Basic quiz information
     id: str
     title: str
-    equations: List[str]
-    variables: List[str]
-    image_mapping: Dict[str, str]  # Variable name -> Pokemon image path
+    equations: list[str]
+    variables: list[str]
+    image_mapping: dict[str, str]  # Variable name -> Pokemon image path
 
     # Optional fields with default values must come after required fields
     description: str = ""
     is_random: bool = False
-    difficulty: Optional[Dict[str, Any]] = None
-    next_quiz_id: Optional[str] = None
+    difficulty: dict[str, Any] | None = None
+    next_quiz_id: str | None = None
     has_next: bool = False
 
     def get_pokemon_image(self, variable: str) -> str:
@@ -40,7 +41,7 @@ class QuizViewModel:
 
             # Replace direct variable name using regex with word boundaries
             # This ensures we only replace standalone variables, not variables that are part of other words
-            pattern = r'\b' + re.escape(var) + r'\b'
+            pattern = r"\b" + re.escape(var) + r"\b"
             result = re.sub(pattern, img_tag, result)
 
             # Also replace {var} placeholders
@@ -49,19 +50,19 @@ class QuizViewModel:
 
         return result
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert the view model to a dictionary for debugging."""
         return {
-            'id': self.id,
-            'title': self.title,
-            'description': self.description,
-            'equations': self.equations,
-            'variables': self.variables,
-            'image_mapping': self.image_mapping,
-            'is_random': self.is_random,
-            'difficulty': self.difficulty,
-            'next_quiz_id': self.next_quiz_id,
-            'has_next': self.has_next
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "equations": self.equations,
+            "variables": self.variables,
+            "image_mapping": self.image_mapping,
+            "is_random": self.is_random,
+            "difficulty": self.difficulty,
+            "next_quiz_id": self.next_quiz_id,
+            "has_next": self.has_next,
         }
 
     def __str__(self) -> str:
@@ -72,19 +73,20 @@ class QuizViewModel:
 @dataclass
 class QuizResultViewModel:
     """View model for quiz results."""
+
     correct: bool
-    correct_answers: Dict[str, bool]  # Variable name -> bool indicating if correct
+    correct_answers: dict[str, bool]  # Variable name -> bool indicating if correct
     all_answered: bool
     correct_count: int
     total_count: int
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
-            'correct': self.correct,
-            'correct_answers': self.correct_answers,
-            'all_answered': self.all_answered,
-            'correct_count': self.correct_count,
-            'total_count': self.total_count
+            "correct": self.correct,
+            "correct_answers": self.correct_answers,
+            "all_answered": self.all_answered,
+            "correct_count": self.correct_count,
+            "total_count": self.total_count,
         }
 
     def __str__(self) -> str:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 """
 Test package for poke-math application.
-""" 
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from src.app.game.game_config import load_game_config
 from src.app.game.game_manager import GameManager
 
 # Add the project root directory to Python path
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
@@ -26,7 +26,7 @@ def test_data_path() -> Path:
     Fixture providing the path to test data file.
     Uses session scope as the path never changes during test run.
     """
-    return Path('tests/data/quizzes.json')
+    return Path("tests/data/quizzes.json")
 
 
 @pytest.fixture(scope="session")
@@ -35,7 +35,7 @@ def test_pokemon_data_path() -> Path:
     Fixture providing the path to test Pokemon data file.
     Uses session scope as the path never changes during test run.
     """
-    return Path('tests/data/pokemons.json')
+    return Path("tests/data/pokemons.json")
 
 
 @pytest.fixture
@@ -56,16 +56,20 @@ def mock_session_manager():
 
     # Create a mock storage
     mock_storage = MagicMock()
-    mock_storage.load_user_data.return_value = {'session_state': {}}
+    mock_storage.load_user_data.return_value = {"session_state": {}}
 
     # Patch _get_or_create_user_id to avoid Flask session dependency
-    with patch('src.app.game.session_manager.SessionManager._get_or_create_user_id', return_value='test_user'):
+    with patch(
+        "src.app.game.session_manager.SessionManager._get_or_create_user_id",
+        return_value="test_user",
+    ):
         # Create session manager with mock storage and test user ID
-        session_manager = SessionManager(storage=mock_storage, user_id='test_user')
+        session_manager = SessionManager(storage=mock_storage, user_id="test_user")
 
         # Initialize with empty state
-        session_manager.state = SessionState(solved_quizzes=set(), quiz_attempts=[], user_name=None, level=1, xp=0,
-                                             caught_pokemon={})
+        session_manager.state = SessionState(
+            solved_quizzes=set(), quiz_attempts=[], user_name=None, level=1, xp=0, caught_pokemon={}
+        )
 
         # Mock _save_state to avoid storage calls
         session_manager._save_state = MagicMock()
@@ -89,5 +93,5 @@ def solved_game_manager(game_manager):
     Useful for testing state-dependent behavior.
     """
     # Solve the basic quiz
-    game_manager.check_answers('test_basic', {'pikachu': 3})
+    game_manager.check_answers("test_basic", {"pikachu": 3})
     return game_manager

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 End-to-end tests for the Pokemath application.
-""" 
+"""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Pytest fixtures for end-to-end testing.
@@ -29,14 +28,14 @@ ensure_screenshots_dir()
 async def browser_context():
     """
     Set up a browser context for testing.
-    
+
     Yields:
         tuple: A tuple containing the playwright instance, browser, context, and page
     """
     # Get headless mode from environment variable
     headless_str = os.environ.get("HEADLESS", "false").lower()
     headless = headless_str == "true"
-    
+
     playwright, browser, context, page = await setup_browser(headless=headless)
     yield playwright, browser, context, page
     await teardown_browser(playwright, browser)
@@ -46,18 +45,18 @@ async def browser_context():
 async def authenticated_browser_context(browser_context):
     """
     Set up an authenticated browser context for testing.
-    
+
     Args:
         browser_context: The browser context fixture
-    
+
     Yields:
         tuple: A tuple containing the playwright instance, browser, context, and page
     """
     playwright, browser, context, page = browser_context
-    
+
     # Log in as guest
     await login_as_guest(page, trainer_name="TestTrainer")
-    
+
     yield playwright, browser, context, page
 
 
@@ -65,10 +64,10 @@ async def authenticated_browser_context(browser_context):
 async def page(browser_context):
     """
     Get the page from the browser context.
-    
+
     Args:
         browser_context: The browser context fixture
-    
+
     Returns:
         Page: The Playwright page object
     """
@@ -80,10 +79,10 @@ async def page(browser_context):
 async def authenticated_page(authenticated_browser_context):
     """
     Get the authenticated page from the browser context.
-    
+
     Args:
         authenticated_browser_context: The authenticated browser context fixture
-    
+
     Returns:
         Page: The authenticated Playwright page object
     """

--- a/tests/e2e/fixtures/__init__.py
+++ b/tests/e2e/fixtures/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Test fixtures for e2e tests.
-""" 
+"""

--- a/tests/e2e/fixtures/adventure.py
+++ b/tests/e2e/fixtures/adventure.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Fixtures for adventure-related e2e tests.
@@ -16,22 +15,20 @@ from tests.e2e.utils.api_helpers import complete_adventure
 async def completed_adventure(authenticated_page: Page):
     """
     Fixture that completes an adventure and returns the response data.
-    
+
     This fixture completes a standard adventure with medium difficulty
     and a few common Pokémon.
-    
+
     Args:
         authenticated_page: The authenticated Playwright page
-        
+
     Returns:
         dict: The parsed JSON response data from the adventure completion
     """
     response, data = await complete_adventure(
-        authenticated_page, 
-        difficulty=3, 
-        caught_pokemon=["pikachu", "bulbasaur", "charmander"]
+        authenticated_page, difficulty=3, caught_pokemon=["pikachu", "bulbasaur", "charmander"]
     )
-    
+
     assert response.ok, f"Adventure completion API call failed with status {response.status}"
     return data
 
@@ -40,24 +37,24 @@ async def completed_adventure(authenticated_page: Page):
 async def player_stats_before_adventure(authenticated_page: Page):
     """
     Fixture that captures player stats before an adventure.
-    
+
     Args:
         authenticated_page: The authenticated Playwright page
-        
+
     Returns:
         dict: Player stats including level, XP, and collection stats
     """
     profile_page = ProfilePage(authenticated_page)
     await profile_page.goto()
-    
+
     level = await profile_page.get_player_level()
     xp, xp_needed = await profile_page.get_player_xp()
     unique_pokemon, total_pokemon = await profile_page.get_collection_stats()
-    
+
     return {
         "level": level,
         "xp": xp,
         "xp_needed": xp_needed,
         "unique_pokemon": unique_pokemon,
-        "total_pokemon": total_pokemon
-    } 
+        "total_pokemon": total_pokemon,
+    }

--- a/tests/e2e/pages/BasePage.py
+++ b/tests/e2e/pages/BasePage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Base Page Object Model class that all other page objects will inherit from.
@@ -12,56 +11,56 @@ from playwright.async_api import Page
 
 class BasePage:
     """Base class for all page objects."""
-    
+
     def __init__(self, page: Page):
         """
         Initialize the base page.
-        
+
         Args:
             page (Page): The Playwright page object
         """
         self.page = page
         self.base_url = os.environ.get("BASE_URL", "http://localhost:8080")
-    
+
     async def goto(self, path: str = ""):
         """
         Navigate to a page.
-        
+
         Args:
             path (str): The path to navigate to, relative to base_url
         """
         full_url = f"{self.base_url}{path}"
         await self.page.goto(full_url)
-    
+
     async def get_title(self) -> str:
         """
         Get the page title.
-        
+
         Returns:
             str: The page title
         """
         return await self.page.title()
-    
+
     async def wait_for_url(self, path: str):
         """
         Wait for the URL to match the expected path.
-        
+
         Args:
             path (str): The expected path, relative to base_url
         """
         full_url = f"{self.base_url}{path}"
         await self.page.wait_for_url(full_url)
-    
+
     async def take_screenshot(self, name: str):
         """
         Take a screenshot of the page.
-        
+
         Args:
             name (str): The name of the screenshot
-        
+
         Returns:
             str: The path to the screenshot
         """
         path = f"tests/e2e/screenshots/{name}.png"
         await self.page.screenshot(path=path, full_page=True)
-        return path 
+        return path

--- a/tests/e2e/pages/HomePage.py
+++ b/tests/e2e/pages/HomePage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Home Page Object Model class for the home page functionality.
@@ -12,88 +11,88 @@ from .BasePage import BasePage
 
 class HomePage(BasePage):
     """Page object for the home page."""
-    
+
     def __init__(self, page: Page):
         """
         Initialize the home page.
-        
+
         Args:
             page (Page): The Playwright page object
         """
         super().__init__(page)
         self.path = "/"
-        
+
         # Locators
         self.welcome_message_locator = "h2"
         self.profile_link_locator = "a[href='/profile']"
         self.my_missions_link_locator = "a[href='/my-quizzes']"
         self.new_mission_link_locator = "a[href='/new-exercise']"
-    
+
     async def goto(self):
         """Navigate to the home page."""
         await super().goto(self.path)
-    
+
     async def is_welcome_message_visible(self):
         """
         Check if the welcome message is visible.
-        
+
         Returns:
             bool: True if the welcome message is visible, False otherwise
         """
         welcome_message = self.page.locator(self.welcome_message_locator)
         await expect(welcome_message).to_be_visible()
         return await welcome_message.is_visible()
-    
+
     async def get_welcome_message_text(self):
         """
         Get the welcome message text.
-        
+
         Returns:
             str: The welcome message text
         """
         return await self.page.locator(self.welcome_message_locator).inner_text()
-    
+
     async def navigate_to_profile(self):
         """
         Navigate to the profile page.
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
         profile_link = self.page.locator(self.profile_link_locator)
         await expect(profile_link).to_be_visible()
         await profile_link.click()
-        
+
         # Wait for navigation to the profile page
         await self.wait_for_url("/profile")
         return True
-    
+
     async def navigate_to_my_missions(self):
         """
         Navigate to the my missions page.
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
         my_missions_link = self.page.locator(self.my_missions_link_locator)
         await expect(my_missions_link).to_be_visible()
         await my_missions_link.click()
-        
+
         # Wait for navigation to the my missions page
         await self.wait_for_url("/my-quizzes")
         return True
-    
+
     async def navigate_to_new_mission(self):
         """
         Navigate to the new mission page.
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
         new_mission_link = self.page.locator(self.new_mission_link_locator)
         await expect(new_mission_link).to_be_visible()
         await new_mission_link.click()
-        
+
         # Wait for navigation to the new mission page
         await self.wait_for_url("/new-exercise")
-        return True 
+        return True

--- a/tests/e2e/pages/LoginPage.py
+++ b/tests/e2e/pages/LoginPage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Login Page Object Model class for the login functionality.
@@ -12,69 +11,69 @@ from .BasePage import BasePage
 
 class LoginPage(BasePage):
     """Page object for the login page."""
-    
+
     def __init__(self, page: Page):
         """
         Initialize the login page.
-        
+
         Args:
             page (Page): The Playwright page object
         """
         super().__init__(page)
         self.path = "/login"
-        
+
         # Locators
         self.guest_button_locator = "button.firebaseui-idp-anonymous"
         self.google_button_locator = "button.firebaseui-idp-google"
         self.title_locator = "h2"
-    
+
     async def goto(self):
         """Navigate to the login page."""
         await super().goto(self.path)
-    
+
     async def is_title_visible(self):
         """
         Check if the login page title is visible.
-        
+
         Returns:
             bool: True if the title is visible, False otherwise
         """
         title = self.page.locator(self.title_locator)
         await expect(title).to_be_visible()
         return await title.is_visible()
-    
+
     async def get_title_text(self):
         """
         Get the login page title text.
-        
+
         Returns:
             str: The title text
         """
         return await self.page.locator(self.title_locator).inner_text()
-    
+
     async def continue_as_guest(self):
         """
         Click the 'Continue as guest' button.
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
         guest_button = self.page.locator(self.guest_button_locator)
         await expect(guest_button).to_be_visible()
         await guest_button.click()
-        
+
         # Wait for navigation to the name input page
         await self.wait_for_url("/name")
         return True
-    
+
     async def sign_in_with_google(self):
         """
         Click the 'Sign in with Google' button.
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
         google_button = self.page.locator(self.google_button_locator)
         await expect(google_button).to_be_visible()
         await google_button.click()
-        return True 
+        return True

--- a/tests/e2e/pages/NamePage.py
+++ b/tests/e2e/pages/NamePage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Name Page Object Model class for the trainer name input functionality.
@@ -12,53 +11,53 @@ from .BasePage import BasePage
 
 class NamePage(BasePage):
     """Page object for the name input page."""
-    
+
     def __init__(self, page: Page):
         """
         Initialize the name page.
-        
+
         Args:
             page (Page): The Playwright page object
         """
         super().__init__(page)
         self.path = "/name"
-        
+
         # Locators
         self.name_input_locator = "input#trainer-name"
         self.save_button_locator = "button.button-blue"
         self.title_locator = "h2"
-    
+
     async def goto(self):
         """Navigate to the name input page."""
         await super().goto(self.path)
-    
+
     async def is_title_visible(self):
         """
         Check if the name page title is visible.
-        
+
         Returns:
             bool: True if the title is visible, False otherwise
         """
         title = self.page.locator(self.title_locator)
         await expect(title).to_be_visible()
         return await title.is_visible()
-    
+
     async def get_title_text(self):
         """
         Get the name page title text.
-        
+
         Returns:
             str: The title text
         """
         return await self.page.locator(self.title_locator).inner_text()
-    
+
     async def enter_name(self, name: str):
         """
         Enter a trainer name.
-        
+
         Args:
             name (str): The trainer name to enter
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
@@ -66,32 +65,32 @@ class NamePage(BasePage):
         await expect(name_input).to_be_visible()
         await name_input.fill(name)
         return True
-    
+
     async def save_name(self):
         """
         Click the 'SAVE NAME' button.
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
         save_button = self.page.locator(self.save_button_locator)
         await expect(save_button).to_be_visible()
         await save_button.click()
-        
+
         # Wait for navigation to the home page
         await self.wait_for_url("/")
         return True
-    
+
     async def set_trainer_name(self, name: str):
         """
         Enter a trainer name and save it.
-        
+
         Args:
             name (str): The trainer name to enter
-        
+
         Returns:
             bool: True if successful, False otherwise
         """
         await self.enter_name(name)
         await self.save_name()
-        return True 
+        return True

--- a/tests/e2e/pages/ProfilePage.py
+++ b/tests/e2e/pages/ProfilePage.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Profile Page Object Model class for the profile page functionality.
@@ -12,40 +11,40 @@ from .BasePage import BasePage
 
 class ProfilePage(BasePage):
     """Page object for the profile page."""
-    
+
     def __init__(self, page: Page):
         """
         Initialize the profile page.
-        
+
         Args:
             page (Page): The Playwright page object
         """
         super().__init__(page)
         self.path = "/profile"
-        
+
         # Locators
         self.title_locator = "h2"
         self.error_message_locator = "body"
-        
+
         # Player level and XP locators
         self.level_value_locator = ".stats-card h3:has-text('Player Level')"
         self.xp_value_locator = ".stats-card .stat-item:has-text('XP:') .stat-value"
         self.xp_progress_bar_locator = ".stats-card .progress-bar"
-        
+
         # Pokémon collection locators
         self.collection_card_locator = ".card h3:has-text('Pokémon Collection')"
         self.collection_progress_text_locator = ".card p:has-text('You have caught')"
         self.collection_progress_bar_locator = ".card .progress-bar.bg-info"
         self.pokemon_cards_locator = ".card .row .col-md-3"
-    
+
     async def goto(self):
         """Navigate to the profile page."""
         await super().goto(self.path)
-    
+
     async def is_title_visible(self):
         """
         Check if the profile page title is visible.
-        
+
         Returns:
             bool: True if the title is visible, False otherwise
         """
@@ -53,49 +52,49 @@ class ProfilePage(BasePage):
             title = self.page.locator(self.title_locator)
             await expect(title).to_be_visible(timeout=5000)
             return await title.is_visible()
-        except:
+        except Exception:
             return False
-    
+
     async def get_title_text(self):
         """
         Get the profile page title text.
-        
+
         Returns:
             str: The title text
         """
         try:
             return await self.page.locator(self.title_locator).inner_text()
-        except:
+        except Exception:
             return ""
-    
+
     async def has_error(self):
         """
         Check if the profile page has an error.
-        
+
         Returns:
             bool: True if there is an error, False otherwise
         """
         try:
             title = await self.page.title()
             return "500" in title or "404" in title or "Error" in title
-        except:
+        except Exception:
             return False
-    
+
     async def get_error_message(self):
         """
         Get the error message if there is an error.
-        
+
         Returns:
             str: The error message
         """
         if await self.has_error():
             return await self.page.locator(self.error_message_locator).inner_text()
         return ""
-    
+
     async def is_level_section_visible(self):
         """
         Check if the player level section is visible.
-        
+
         Returns:
             bool: True if the level section is visible, False otherwise
         """
@@ -103,41 +102,43 @@ class ProfilePage(BasePage):
             level_value = self.page.locator(self.level_value_locator)
             await expect(level_value).to_be_visible(timeout=5000)
             return await level_value.is_visible()
-        except:
+        except Exception:
             return False
-    
+
     async def get_player_level(self):
         """
         Get the player level.
-        
+
         Returns:
             int: The player level
         """
         try:
             # Find the level value in the stat-item that contains "Level:"
-            level_text = await self.page.locator(".stats-card .stat-item:has-text('Level:') .stat-value").inner_text()
+            level_text = await self.page.locator(
+                ".stats-card .stat-item:has-text('Level:') .stat-value"
+            ).inner_text()
             return int(level_text)
-        except:
+        except Exception:
             return 0
-    
+
     async def get_player_xp(self):
         """
         Get the player XP.
-        
+
         Returns:
             tuple: (current_xp, xp_needed)
         """
         try:
             xp_text = await self.page.locator(self.xp_value_locator).inner_text()
-            current_xp, xp_needed = xp_text.split('/')
+            current_xp, xp_needed = xp_text.split("/")
             return int(current_xp), int(xp_needed)
-        except:
+        except Exception:
             return 0, 0
-    
+
     async def is_collection_section_visible(self):
         """
         Check if the Pokémon collection section is visible.
-        
+
         Returns:
             bool: True if the collection section is visible, False otherwise
         """
@@ -145,13 +146,13 @@ class ProfilePage(BasePage):
             collection_card = self.page.locator(self.collection_card_locator)
             await expect(collection_card).to_be_visible(timeout=5000)
             return await collection_card.is_visible()
-        except:
+        except Exception:
             return False
-    
+
     async def get_collection_stats(self):
         """
         Get the Pokémon collection stats.
-        
+
         Returns:
             tuple: (unique_pokemon, total_pokemon)
         """
@@ -166,16 +167,16 @@ class ProfilePage(BasePage):
             # If there's an error parsing the stats, return default values
             # This ensures the test doesn't fail if the user has no Pokémon yet
             return 0, 1  # Return at least 1 for total_pokemon to pass the test
-    
+
     async def get_pokemon_count(self):
         """
         Get the number of Pokémon cards displayed in the collection.
-        
+
         Returns:
             int: The number of Pokémon cards
         """
         try:
             cards = self.page.locator(self.pokemon_cards_locator)
             return await cards.count()
-        except:
-            return 0 
+        except Exception:
+            return 0

--- a/tests/e2e/pages/__init__.py
+++ b/tests/e2e/pages/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Page Object Model classes for end-to-end testing.
@@ -11,10 +10,4 @@ from .LoginPage import LoginPage
 from .NamePage import NamePage
 from .ProfilePage import ProfilePage
 
-__all__ = [
-    'BasePage',
-    'LoginPage',
-    'NamePage',
-    'HomePage',
-    'ProfilePage'
-] 
+__all__ = ["BasePage", "HomePage", "LoginPage", "NamePage", "ProfilePage"]

--- a/tests/e2e/specs/__init__.py
+++ b/tests/e2e/specs/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Profile tests for the Pokemath application.
-""" 
+"""

--- a/tests/e2e/specs/test_adventure.py
+++ b/tests/e2e/specs/test_adventure.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Tests for the adventure completion functionality.
 This file focuses on adventure mechanics rather than player progression.
 """
-
 
 import pytest
 from playwright.async_api import Page
@@ -24,58 +22,64 @@ async def test_adventure_completion_api(authenticated_page: Page, player_stats_b
     # Arrange - Get initial player stats from fixture
     initial_stats = player_stats_before_adventure
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Take a screenshot - Initial state
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('adventure_completion_initial')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Act - Call the adventure completion API using our helper
     response, response_data = await complete_adventure(
-        authenticated_page,
-        difficulty=3,
-        caught_pokemon=["pikachu", "bulbasaur", "charmander"]
+        authenticated_page, difficulty=3, caught_pokemon=["pikachu", "bulbasaur", "charmander"]
     )
-    
+
     # Assert - Check the response
     assert response.ok, f"Adventure completion API call failed with status {response.status}"
-    
+
     # Verify response structure using our helper
     verify_adventure_response_structure(response_data)
-    
+
     # Check that XP was gained
     assert response_data["xp_gained"] > 0, "XP gained should be positive"
-    
+
     # Check that Pokémon were caught
     for pokemon_id in ["pikachu", "bulbasaur", "charmander"]:
-        assert pokemon_id in response_data["pokemon_counts"], f"Pokemon {pokemon_id} should be in pokemon_counts"
-        assert response_data["pokemon_counts"][pokemon_id] > 0, f"Pokemon {pokemon_id} count should be positive"
-    
+        assert pokemon_id in response_data["pokemon_counts"], (
+            f"Pokemon {pokemon_id} should be in pokemon_counts"
+        )
+        assert response_data["pokemon_counts"][pokemon_id] > 0, (
+            f"Pokemon {pokemon_id} count should be positive"
+        )
+
     # Reload the profile page to see the changes
     await profile_page.goto()
-    
+
     # Take a screenshot - After adventure
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('adventure_completion_after')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Check for errors
     if await profile_page.has_error():
         error_message = await profile_page.get_error_message()
         pytest.fail(f"Profile page has an error: {error_message}")
-    
+
     # Get updated stats
     updated_level = await profile_page.get_player_level()
     updated_xp, _ = await profile_page.get_player_xp()
     updated_unique_pokemon, _ = await profile_page.get_collection_stats()
-    
+
     # Check that level or XP increased
-    assert updated_level > initial_stats["level"] or updated_xp > initial_stats["xp"], "Player level or XP should increase after adventure"
-    
+    assert updated_level > initial_stats["level"] or updated_xp > initial_stats["xp"], (
+        "Player level or XP should increase after adventure"
+    )
+
     # Check that Pokémon collection increased
-    assert updated_unique_pokemon >= initial_stats["unique_pokemon"], "Unique Pokémon count should not decrease after adventure"
+    assert updated_unique_pokemon >= initial_stats["unique_pokemon"], (
+        "Unique Pokémon count should not decrease after adventure"
+    )
 
 
 @pytest.mark.asyncio
@@ -83,31 +87,27 @@ async def test_adventure_difficulty_scaling(authenticated_page: Page):
     """Test that adventure difficulty affects rewards appropriately."""
     # Test with difficulty 1 (lowest)
     low_difficulty_response, low_difficulty_data = await complete_adventure(
-        authenticated_page, 
-        difficulty=1, 
-        caught_pokemon=["pikachu"]
+        authenticated_page, difficulty=1, caught_pokemon=["pikachu"]
     )
-    
+
     low_difficulty_xp = low_difficulty_data["xp_gained"]
-    
+
     # Test with difficulty 7 (highest)
     high_difficulty_response, high_difficulty_data = await complete_adventure(
-        authenticated_page, 
-        difficulty=7, 
-        caught_pokemon=["pikachu"]
+        authenticated_page, difficulty=7, caught_pokemon=["pikachu"]
     )
-    
+
     high_difficulty_xp = high_difficulty_data["xp_gained"]
-    
+
     # Assert - Higher difficulty should give more XP
     assert high_difficulty_xp > low_difficulty_xp, "Higher difficulty should give more XP"
-    
+
     # Take a screenshot
     profile_page = ProfilePage(authenticated_page)
     await profile_page.goto()
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('adventure_difficulty_scaling')}.png",
-        full_page=True
+        full_page=True,
     )
 
 
@@ -116,21 +116,17 @@ async def test_adventure_pokemon_quantity(authenticated_page: Page):
     """Test that catching more Pokémon in an adventure gives more rewards."""
     # Test with one Pokémon
     single_pokemon_response, single_pokemon_data = await complete_adventure(
-        authenticated_page, 
-        difficulty=3, 
-        caught_pokemon=["pikachu"]
+        authenticated_page, difficulty=3, caught_pokemon=["pikachu"]
     )
-    
+
     single_pokemon_xp = single_pokemon_data["xp_gained"]
-    
+
     # Test with multiple Pokémon
     multiple_pokemon_response, multiple_pokemon_data = await complete_adventure(
-        authenticated_page, 
-        difficulty=3, 
-        caught_pokemon=["pikachu", "bulbasaur", "charmander"]
+        authenticated_page, difficulty=3, caught_pokemon=["pikachu", "bulbasaur", "charmander"]
     )
-    
+
     multiple_pokemon_xp = multiple_pokemon_data["xp_gained"]
-    
+
     # Assert - More Pokémon should give more XP
     assert multiple_pokemon_xp > single_pokemon_xp, "Catching more Pokémon should give more XP"

--- a/tests/e2e/specs/test_login.py
+++ b/tests/e2e/specs/test_login.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Tests for the login functionality.
@@ -17,19 +16,21 @@ async def test_login_page_loads(page: Page):
     """Test that the login page loads correctly."""
     # Arrange
     login_page = LoginPage(page)
-    
+
     # Act
     await login_page.goto()
-    
+
     # Assert
     assert await login_page.is_title_visible(), "Login page title should be visible"
     title_text = await login_page.get_title_text()
-    assert "Welcome to Pokemath!" in title_text, f"Expected 'Welcome to Pokemath!' in title, got '{title_text}'"
-    
+    assert "Welcome to Pokemath!" in title_text, (
+        f"Expected 'Welcome to Pokemath!' in title, got '{title_text}'"
+    )
+
     # Take a screenshot
     await page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('login_page_loads')}.png",
-        full_page=True
+        full_page=True,
     )
 
 
@@ -41,43 +42,47 @@ async def test_guest_login_flow(page: Page):
     name_page = NamePage(page)
     home_page = HomePage(page)
     trainer_name = "TestTrainer"
-    
+
     # Act - Step 1: Navigate to login page
     await login_page.goto()
-    
+
     # Assert - Step 1
     assert await login_page.is_title_visible(), "Login page title should be visible"
-    
+
     # Take a screenshot - Step 1
     await page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('guest_login_step1')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Act - Step 2: Continue as guest
     await login_page.continue_as_guest()
-    
+
     # Assert - Step 2
     assert await name_page.is_title_visible(), "Name page title should be visible"
     title_text = await name_page.get_title_text()
-    assert "Choose Your Trainer Name!" in title_text, f"Expected 'Choose Your Trainer Name!' in title, got '{title_text}'"
-    
+    assert "Choose Your Trainer Name!" in title_text, (
+        f"Expected 'Choose Your Trainer Name!' in title, got '{title_text}'"
+    )
+
     # Take a screenshot - Step 2
     await page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('guest_login_step2')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Act - Step 3: Enter trainer name and save
     await name_page.set_trainer_name(trainer_name)
-    
+
     # Assert - Step 3
-    assert await home_page.is_welcome_message_visible(), "Home page welcome message should be visible"
-    
+    assert await home_page.is_welcome_message_visible(), (
+        "Home page welcome message should be visible"
+    )
+
     # Take a screenshot - Step 3
     await page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('guest_login_step3')}.png",
-        full_page=True
+        full_page=True,
     )
 
 
@@ -86,16 +91,16 @@ async def test_google_login_button(page: Page):
     """Test that the Google login button is visible and clickable."""
     # Arrange
     login_page = LoginPage(page)
-    
+
     # Act
     await login_page.goto()
-    
+
     # Assert
     google_button = page.locator(login_page.google_button_locator)
     await expect(google_button).to_be_visible()
-    
+
     # Take a screenshot
     await page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('google_login_button')}.png",
-        full_page=True
-    ) 
+        full_page=True,
+    )

--- a/tests/e2e/specs/test_player_progression.py
+++ b/tests/e2e/specs/test_player_progression.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Tests for the player progression features.
 These tests verify that the core player progression features are working correctly.
 """
-
 
 import pytest
 from playwright.async_api import Page
@@ -20,28 +18,28 @@ async def test_player_level_display(authenticated_page: Page):
     """Test that player level is displayed correctly on the profile page."""
     # Arrange
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Act - Navigate to profile page
     await profile_page.goto()
-    
+
     # Take a screenshot
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('smoke_player_level')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Check for errors
     if await profile_page.has_error():
         error_message = await profile_page.get_error_message()
         pytest.fail(f"Profile page has an error: {error_message}")
-    
+
     # Assert - Check that player level section is visible
     assert await profile_page.is_level_section_visible(), "Player level section should be visible"
-    
+
     # Get player level and XP
     level = await profile_page.get_player_level()
     current_xp, xp_needed = await profile_page.get_player_xp()
-    
+
     # Verify level and XP are reasonable values
     assert level >= 1, "Player level should be at least 1"
     assert current_xp >= 0, "Current XP should be non-negative"
@@ -54,23 +52,25 @@ async def test_pokemon_collection_section(authenticated_page: Page):
     """Test that Pokémon collection section is displayed correctly on the profile page."""
     # Arrange
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Act - Navigate to profile page
     await profile_page.goto()
-    
+
     # Take a screenshot
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('smoke_pokemon_collection')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Check for errors
     if await profile_page.has_error():
         error_message = await profile_page.get_error_message()
         pytest.fail(f"Profile page has an error: {error_message}")
-    
+
     # Assert - Check that Pokémon collection section is visible
-    assert await profile_page.is_collection_section_visible(), "Pokémon collection section should be visible"
+    assert await profile_page.is_collection_section_visible(), (
+        "Pokémon collection section should be visible"
+    )
 
 
 @pytest.mark.asyncio
@@ -78,45 +78,47 @@ async def test_xp_calculation(authenticated_page: Page, player_stats_before_adve
     """Test that XP is calculated correctly for different Pokémon tiers and difficulties."""
     # Arrange - Get initial level and XP from fixture
     initial_stats = player_stats_before_adventure
-    
+
     # Act - Call the adventure completion API with different difficulties using our helper
     # Test with difficulty 1 (lowest)
     _, low_difficulty_data = await complete_adventure(
         authenticated_page,
         difficulty=1,
-        caught_pokemon=["pikachu"]  # Tier 2 Pokémon
+        caught_pokemon=["pikachu"],  # Tier 2 Pokémon
     )
-    
+
     low_difficulty_xp = low_difficulty_data["xp_gained"]
-    
+
     # Test with difficulty 7 (highest)
     _, high_difficulty_data = await complete_adventure(
         authenticated_page,
         difficulty=7,
-        caught_pokemon=["pikachu"]  # Same Pokémon for fair comparison
+        caught_pokemon=["pikachu"],  # Same Pokémon for fair comparison
     )
-    
+
     high_difficulty_xp = high_difficulty_data["xp_gained"]
-    
+
     # Assert - Higher difficulty should give more XP
     assert high_difficulty_xp > low_difficulty_xp, "Higher difficulty should give more XP"
-    
+
     # Reload profile page to see final state
     profile_page = ProfilePage(authenticated_page)
     await profile_page.goto()
-    
+
     # Take a screenshot
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('smoke_xp_calculation')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Get final level and XP
     final_level = await profile_page.get_player_level()
     final_xp, _ = await profile_page.get_player_xp()
-    
+
     # Check that XP or level increased
-    assert final_level > initial_stats["level"] or final_xp > initial_stats["xp"], "Player level or XP should increase after adventures"
+    assert final_level > initial_stats["level"] or final_xp > initial_stats["xp"], (
+        "Player level or XP should increase after adventures"
+    )
 
 
 @pytest.mark.asyncio
@@ -127,29 +129,29 @@ async def test_pokemon_tier_xp_rewards(authenticated_page: Page):
     _, tier2_data = await complete_adventure(
         authenticated_page,
         difficulty=1,
-        caught_pokemon=["pikachu"]  # Tier 2 Pokémon
+        caught_pokemon=["pikachu"],  # Tier 2 Pokémon
     )
-    
+
     tier2_xp = tier2_data["xp_gained"]
-    
+
     # Test with a tier 5 Pokémon (mew)
     _, tier5_data = await complete_adventure(
         authenticated_page,
         difficulty=1,
-        caught_pokemon=["mew"]  # Tier 5 Pokémon
+        caught_pokemon=["mew"],  # Tier 5 Pokémon
     )
-    
+
     tier5_xp = tier5_data["xp_gained"]
-    
+
     # Assert - Higher tier should give more XP
     assert tier5_xp > tier2_xp, "Higher tier Pokémon should give more XP"
-    
+
     # Take a screenshot
     profile_page = ProfilePage(authenticated_page)
     await profile_page.goto()
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('smoke_pokemon_tier_xp')}.png",
-        full_page=True
+        full_page=True,
     )
 
 
@@ -159,40 +161,40 @@ async def test_level_up_progression(authenticated_page: Page, player_stats_befor
     # Arrange - Get initial level and XP from fixture
     initial_stats = player_stats_before_adventure
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Calculate how much XP is needed to level up
     xp_needed_for_level_up = initial_stats["xp_needed"] - initial_stats["xp"]
-    
+
     # We'll need to complete multiple adventures to gain enough XP to level up
     # Keep track of total XP gained
     total_xp_gained = 0
-    
+
     # Complete adventures until we gain enough XP to level up
     while total_xp_gained < xp_needed_for_level_up:
         # Complete a high-difficulty adventure with high-tier Pokémon for maximum XP
         _, response_data = await complete_adventure(
             authenticated_page,
             difficulty=7,
-            caught_pokemon=["mew", "mewtwo", "lugia"]  # High-tier Pokémon
+            caught_pokemon=["mew", "mewtwo", "lugia"],  # High-tier Pokémon
         )
-        
+
         total_xp_gained += response_data["xp_gained"]
-        
+
         # If the API indicates we've leveled up, break out of the loop
         if response_data["leveled_up"]:
             break
-    
+
     # Reload profile page to see final state
     await profile_page.goto()
-    
+
     # Take a screenshot
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('level_up_progression')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Get final level
     final_level = await profile_page.get_player_level()
-    
+
     # Assert - Player should have leveled up
-    assert final_level > initial_stats["level"], "Player should level up after gaining enough XP" 
+    assert final_level > initial_stats["level"], "Player should level up after gaining enough XP"

--- a/tests/e2e/specs/test_profile.py
+++ b/tests/e2e/specs/test_profile.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Tests for the profile page functionality.
@@ -17,36 +16,38 @@ async def test_profile_page_navigation(authenticated_page: Page):
     """Test navigation to the profile page from the home page."""
     # Arrange
     home_page = HomePage(authenticated_page)
-    
+
     # Act - Navigate to home page
     await home_page.goto()
-    
+
     # Assert - Home page loaded
-    assert await home_page.is_welcome_message_visible(), "Home page welcome message should be visible"
-    
+    assert await home_page.is_welcome_message_visible(), (
+        "Home page welcome message should be visible"
+    )
+
     # Take a screenshot - Home page
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('profile_nav_step1')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Act - Navigate to profile page
     await home_page.navigate_to_profile()
-    
+
     # Take a screenshot - Profile page
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('profile_nav_step2')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Assert - Check that the profile page is displayed correctly
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Check for errors
     if await profile_page.has_error():
         error_message = await profile_page.get_error_message()
         pytest.fail(f"Profile page has an error: {error_message}")
-    
+
     assert await profile_page.is_title_visible(), "Profile page title should be visible"
 
 
@@ -55,21 +56,21 @@ async def test_direct_profile_page_access(authenticated_page: Page):
     """Test direct access to the profile page."""
     # Arrange
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Act - Navigate directly to profile page
     await profile_page.goto()
-    
+
     # Take a screenshot
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('direct_profile_access')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Check for errors
     if await profile_page.has_error():
         error_message = await profile_page.get_error_message()
         pytest.fail(f"Profile page has an error: {error_message}")
-    
+
     # Assert - Check that the profile page is displayed correctly
     assert await profile_page.is_title_visible(), "Profile page title should be visible"
 
@@ -79,28 +80,28 @@ async def test_player_progression_display(authenticated_page: Page):
     """Test that player progression information is displayed correctly."""
     # Arrange
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Act - Navigate to profile page
     await profile_page.goto()
-    
+
     # Take a screenshot
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('player_progression')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Check for errors
     if await profile_page.has_error():
         error_message = await profile_page.get_error_message()
         pytest.fail(f"Profile page has an error: {error_message}")
-    
+
     # Assert - Check that player level and XP are displayed
     assert await profile_page.is_level_section_visible(), "Player level section should be visible"
-    
+
     # Get player level and XP
     level = await profile_page.get_player_level()
     current_xp, xp_needed = await profile_page.get_player_xp()
-    
+
     # Verify level and XP are reasonable values
     assert level >= 1, "Player level should be at least 1"
     assert current_xp >= 0, "Current XP should be non-negative"
@@ -113,32 +114,38 @@ async def test_pokemon_collection_display(authenticated_page: Page):
     """Test that Pokémon collection is displayed correctly."""
     # Arrange
     profile_page = ProfilePage(authenticated_page)
-    
+
     # Act - Navigate to profile page
     await profile_page.goto()
-    
+
     # Take a screenshot
     await authenticated_page.screenshot(
         path=f"tests/e2e/screenshots/{generate_screenshot_name('pokemon_collection')}.png",
-        full_page=True
+        full_page=True,
     )
-    
+
     # Check for errors
     if await profile_page.has_error():
         error_message = await profile_page.get_error_message()
         pytest.fail(f"Profile page has an error: {error_message}")
-    
+
     # Assert - Check that Pokémon collection is displayed
-    assert await profile_page.is_collection_section_visible(), "Pokémon collection section should be visible"
-    
+    assert await profile_page.is_collection_section_visible(), (
+        "Pokémon collection section should be visible"
+    )
+
     # Get collection stats
     unique_pokemon, total_pokemon = await profile_page.get_collection_stats()
-    
+
     # Verify collection stats are reasonable values
     assert unique_pokemon >= 0, "Unique Pokémon count should be non-negative"
     assert total_pokemon > 0, "Total Pokémon count should be positive"
-    assert unique_pokemon <= total_pokemon, "Unique Pokémon count should not exceed total Pokémon count"
-    
+    assert unique_pokemon <= total_pokemon, (
+        "Unique Pokémon count should not exceed total Pokémon count"
+    )
+
     # Check that the number of Pokémon cards matches the unique Pokémon count
     pokemon_count = await profile_page.get_pokemon_count()
-    assert pokemon_count == unique_pokemon, f"Number of Pokémon cards ({pokemon_count}) should match unique Pokémon count ({unique_pokemon})" 
+    assert pokemon_count == unique_pokemon, (
+        f"Number of Pokémon cards ({pokemon_count}) should match unique Pokémon count ({unique_pokemon})"
+    )

--- a/tests/e2e/utils/__init__.py
+++ b/tests/e2e/utils/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Utility functions for end-to-end testing.
-""" 
+"""

--- a/tests/e2e/utils/api_helpers.py
+++ b/tests/e2e/utils/api_helpers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Helper functions for API calls in e2e tests.
@@ -13,36 +12,33 @@ from playwright.async_api import Page
 async def complete_adventure(page: Page, difficulty: int, caught_pokemon: list[str]):
     """
     Helper to call the adventure completion API.
-    
+
     Args:
         page: The Playwright page object
         difficulty: The difficulty level of the adventure (1-7)
         caught_pokemon: List of Pokémon IDs that were caught
-        
+
     Returns:
         tuple: (response, response_data) - The raw response and parsed JSON data
     """
-    payload = {
-        "difficulty": difficulty,
-        "caught_pokemon": caught_pokemon
-    }
-    
+    payload = {"difficulty": difficulty, "caught_pokemon": caught_pokemon}
+
     response = await page.request.post(
         "http://localhost:8080/adventure/complete",
         data=json.dumps(payload),
-        headers={"Content-Type": "application/json"}
+        headers={"Content-Type": "application/json"},
     )
-    
+
     return response, await response.json()
 
 
 async def verify_adventure_response_structure(response_data: dict):
     """
     Verify that the adventure completion API response has the expected structure.
-    
+
     Args:
         response_data: The parsed JSON response data
-        
+
     Returns:
         bool: True if the structure is valid, raises AssertionError otherwise
     """
@@ -52,10 +48,10 @@ async def verify_adventure_response_structure(response_data: dict):
     assert "pokemon_counts" in response_data, "Response should include pokemon_counts"
     assert "leveled_up" in response_data, "Response should include leveled_up"
     assert "level_info" in response_data, "Response should include level_info"
-    
+
     # Check level_info structure
     assert "level" in response_data["level_info"], "level_info should include level"
     assert "xp" in response_data["level_info"], "level_info should include xp"
     assert "xp_needed" in response_data["level_info"], "level_info should include xp_needed"
-    
-    return True 
+
+    return True

--- a/tests/e2e/utils/test_helpers.py
+++ b/tests/e2e/utils/test_helpers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 Helper functions for end-to-end testing.
@@ -13,13 +12,13 @@ from playwright.async_api import Page, async_playwright
 from tests.e2e.pages import LoginPage, NamePage
 
 
-async def setup_browser(headless: bool = None):
+async def setup_browser(headless: bool | None = None):
     """
     Set up a browser for testing.
-    
+
     Args:
         headless (bool): Whether to run the browser in headless mode
-    
+
     Returns:
         tuple: A tuple containing the playwright instance, browser, context, and page
     """
@@ -27,7 +26,7 @@ async def setup_browser(headless: bool = None):
     if headless is None:
         headless_str = os.environ.get("HEADLESS", "false").lower()
         headless = headless_str == "true"
-    
+
     playwright = await async_playwright().start()
     browser = await playwright.chromium.launch(headless=headless)
     context = await browser.new_context()
@@ -38,7 +37,7 @@ async def setup_browser(headless: bool = None):
 async def teardown_browser(playwright, browser):
     """
     Tear down a browser after testing.
-    
+
     Args:
         playwright: The playwright instance
         browser: The browser instance
@@ -50,32 +49,32 @@ async def teardown_browser(playwright, browser):
 async def login_as_guest(page: Page, trainer_name: str = "TestTrainer"):
     """
     Log in as a guest and set a trainer name.
-    
+
     Args:
         page (Page): The Playwright page object
         trainer_name (str): The trainer name to use
-    
+
     Returns:
         bool: True if successful, False otherwise
     """
     # Navigate to the login page
     login_page = LoginPage(page)
     await login_page.goto()
-    
+
     # Continue as guest
     await login_page.continue_as_guest()
-    
+
     # Set trainer name
     name_page = NamePage(page)
     await name_page.set_trainer_name(trainer_name)
-    
+
     return True
 
 
 def ensure_screenshots_dir():
     """
     Ensure the screenshots directory exists.
-    
+
     Returns:
         str: The path to the screenshots directory
     """
@@ -87,12 +86,12 @@ def ensure_screenshots_dir():
 def generate_screenshot_name(test_name: str):
     """
     Generate a screenshot name based on the test name and current timestamp.
-    
+
     Args:
         test_name (str): The name of the test
-    
+
     Returns:
         str: The screenshot name
     """
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    return f"{test_name}_{timestamp}" 
+    return f"{test_name}_{timestamp}"

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,3 @@
 """
 Unit tests package for poke-math application.
-""" 
+"""

--- a/tests/unit/test_collection_display.py
+++ b/tests/unit/test_collection_display.py
@@ -1,6 +1,7 @@
 """
 Unit tests for Pokémon collection display.
 """
+
 from unittest.mock import MagicMock
 
 from src.app.game.game_config import GameConfig, Pokemon
@@ -10,56 +11,58 @@ def test_prepare_collection_data():
     """Test preparing collection data for the template."""
     # Create a mock game manager
     mock_game_manager = MagicMock()
-    
+
     # Create a mock session manager
     mock_session_manager = MagicMock()
     mock_session_manager.get_caught_pokemon.return_value = {
         "pikachu": 2,
         "bulbasaur": 1,
-        "unknown": 3  # This one should be filtered out
+        "unknown": 3,  # This one should be filtered out
     }
-    
+
     # Create a mock game config
     mock_game_config = MagicMock(spec=GameConfig)
     mock_game_config.pokemons = {
         "pikachu": Pokemon(name="Pikachu", image_path="pikachu.png", tier=2),
         "bulbasaur": Pokemon(name="Bulbasaur", image_path="bulbasaur.png", tier=2),
-        "charmander": Pokemon(name="Charmander", image_path="charmander.png", tier=2)
+        "charmander": Pokemon(name="Charmander", image_path="charmander.png", tier=2),
     }
-    
+
     # Set up the game manager
     mock_game_manager.session_manager = mock_session_manager
     mock_game_manager.game_config = mock_game_config
-    
+
     # Get caught Pokémon
     caught_pokemon = mock_session_manager.get_caught_pokemon()
-    
+
     # Prepare collection data for the template
     collection = []
     for pokemon_id, count in caught_pokemon.items():
         if pokemon_id in mock_game_config.pokemons:
             pokemon = mock_game_config.pokemons[pokemon_id]
-            collection.append({
-                'id': pokemon_id,
-                'name': pokemon.name,
-                'image_path': pokemon.image_path,
-                'count': count
-            })
-    
+            collection.append(
+                {
+                    "id": pokemon_id,
+                    "name": pokemon.name,
+                    "image_path": pokemon.image_path,
+                    "count": count,
+                }
+            )
+
     # Sort by name
-    collection.sort(key=lambda p: p['name'])
-    
+    collection.sort(key=lambda p: p["name"])
+
     # Calculate totals
     total_unique_pokemon = len(caught_pokemon)
     total_available_pokemon = len(mock_game_config.pokemons)
-    
+
     # Check that the collection data is correct
     assert len(collection) == 2  # Only pikachu and bulbasaur should be included
-    assert collection[0]['name'] == "Bulbasaur"  # Should be sorted by name
-    assert collection[1]['name'] == "Pikachu"
-    assert collection[0]['count'] == 1
-    assert collection[1]['count'] == 2
-    
+    assert collection[0]["name"] == "Bulbasaur"  # Should be sorted by name
+    assert collection[1]["name"] == "Pikachu"
+    assert collection[0]["count"] == 1
+    assert collection[1]["count"] == 2
+
     # Check that the totals are correct
     assert total_unique_pokemon == 3  # Including the unknown one
-    assert total_available_pokemon == 3  # All Pokémon in the game config 
+    assert total_available_pokemon == 3  # All Pokémon in the game config

--- a/tests/unit/test_equations_generator_v2.py
+++ b/tests/unit/test_equations_generator_v2.py
@@ -1,4 +1,3 @@
-
 import pytest
 import sympy as sp
 
@@ -28,6 +27,7 @@ During development, you can focus on implementing one section at a time and run 
 while skipping the others that are expected to fail until their respective functions are implemented.
 """
 
+
 class TestEquationsGeneratorV2:
     """Test suite for the EquationsGeneratorV2 class."""
 
@@ -35,178 +35,198 @@ class TestEquationsGeneratorV2:
     def generator(self):
         """Return an instance of EquationsGeneratorV2 for testing."""
         return EquationsGeneratorV2()
-    
+
     # Common tests for all equation types
     @pytest.mark.common
     def test_initialization(self, generator):
         """Test that the generator initializes correctly."""
         assert isinstance(generator, EquationsGeneratorV2)
-        assert generator.variables == list('xyzwvu')
-        assert generator.operations == ['+', '-', '*', '/']
-    
+        assert generator.variables == list("xyzwvu")
+        assert generator.operations == ["+", "-", "*", "/"]
+
     @pytest.mark.common
     def test_generate_equations_invalid_type(self, generator):
         """Test that generate_equations raises an error for invalid equation types."""
         with pytest.raises(ValueError):
             generator.generate_equations({"type": "invalid_type"})
-    
+
     @pytest.mark.common
     def test_generate_equations_missing_type(self, generator):
         """Test that generate_equations raises an error when type is missing."""
         with pytest.raises(ValueError):
             generator.generate_equations({})
-    
+
     # Basic Math tests
     @pytest.mark.basic_math
     def test_basic_math_default_params(self, generator):
         """Test basic math generation with default parameters."""
         quiz = generator.generate_basic_math()
-        
+
         # Check that we have one equation
         assert len(quiz.equations) == 1
-        
+
         # Check that the equation has the expected format (x = ...)
         eq_str = quiz.equations[0].formatted
         assert eq_str.startswith("x =")
-        
+
         # Check that the solution exists and is correct
         assert "x" in quiz.solution.human_readable
-        
+
         # Verify the solution is correct by evaluating the equation
         x_value = quiz.solution.human_readable["x"]
         right_side = eq_str.split("=")[1].strip()
         assert x_value == eval(right_side)  # Safe to use eval here for testing
-    
+
     @pytest.mark.basic_math
     def test_basic_math_operations(self, generator):
         """Test basic math generation with different operations."""
         operations = ["+", "-"]
         quiz = generator.generate_basic_math(operations=operations)
-        
+
         # Check that only the specified operations are used
         eq_str = quiz.equations[0].formatted
         right_side = eq_str.split("=")[1].strip()
-        
+
         # The right side should only contain the specified operations
         for op in ["+", "-"]:
             if op in operations:
                 pass  # Operation is allowed
             else:
                 assert op not in right_side, f"Operation {op} should not be in equation"
-    
+
     @pytest.mark.basic_math
     def test_basic_math_max_value(self, generator):
         """Test basic math generation with different max values."""
         max_value = 10
         quiz = generator.generate_basic_math(max_value=max_value)
-        
+
         # Check that all values in the equation are within the max value
         eq_str = quiz.equations[0].formatted
         right_side = eq_str.split("=")[1].strip()
-        
+
         # Extract all numbers from the right side
         import re
-        numbers = re.findall(r'\d+', right_side)
+
+        numbers = re.findall(r"\d+", right_side)
         for num in numbers:
             assert int(num) <= max_value, f"Value {num} exceeds max value {max_value}"
-    
+
     @pytest.mark.basic_math
     def test_basic_math_allow_decimals(self, generator):
         """Test basic math generation with decimal values."""
         # Test with decimals allowed
         quiz_with_decimals = generator.generate_basic_math(allow_decimals=True)
-        
+
         # Test with decimals not allowed
         quiz_without_decimals = generator.generate_basic_math(allow_decimals=False)
-        
+
         # For quiz_without_decimals, check that all values are integers
         eq_str = quiz_without_decimals.equations[0].formatted
         right_side = eq_str.split("=")[1].strip()
-        
+
         # Check if the solution is an integer
         assert isinstance(quiz_without_decimals.solution.human_readable["x"], int)
-        
+
         # For quiz_with_decimals, we can't guarantee decimals will be used,
         # but we can check that the solution is correct
         x_value = quiz_with_decimals.solution.human_readable["x"]
         right_side = quiz_with_decimals.equations[0].formatted.split("=")[1].strip()
         assert abs(x_value - eval(right_side)) < 1e-10  # Use approximate equality for floats
-    
+
     @pytest.mark.basic_math
     def test_basic_math_elements(self, generator):
         """Test basic math generation with different numbers of elements."""
         for elements in range(2, 5):
             quiz = generator.generate_basic_math(elements=elements)
-            
+
             # Check that the equation has the expected number of elements
             eq_str = quiz.equations[0].formatted
             right_side = eq_str.split("=")[1].strip()
-            
+
             # Count the number of operations (which is elements - 1)
             import re
-            operations_count = len(re.findall(r'[\+\-\*\/]', right_side))
-            assert operations_count == elements - 1, f"Expected {elements-1} operations for {elements} elements, got {operations_count}"
-    
+
+            operations_count = len(re.findall(r"[\+\-\*\/]", right_side))
+            assert operations_count == elements - 1, (
+                f"Expected {elements - 1} operations for {elements} elements, got {operations_count}"
+            )
+
     @pytest.mark.basic_math
     def test_basic_math_solution_correctness(self, generator):
         """Test that the solutions provided are correct for basic math equations."""
         # Test with various configurations
         configurations = [
             {"operations": ["+", "-"], "max_value": 20, "allow_decimals": False, "elements": 2},
-            {"operations": ["+", "-", "*"], "max_value": 10, "allow_decimals": False, "elements": 3},
-            {"operations": ["+", "-", "*", "/"], "max_value": 30, "allow_decimals": True, "elements": 4},
+            {
+                "operations": ["+", "-", "*"],
+                "max_value": 10,
+                "allow_decimals": False,
+                "elements": 3,
+            },
+            {
+                "operations": ["+", "-", "*", "/"],
+                "max_value": 30,
+                "allow_decimals": True,
+                "elements": 4,
+            },
         ]
-        
+
         for config in configurations:
             quiz = generator.generate_basic_math(**config)
-            
+
             # Check each equation
             for eq in quiz.equations:
                 # If the equation is a string with an equals sign, convert it to a SymPy equation
-                if isinstance(eq.symbolic, str) and '=' in eq.symbolic:
-                    sides = eq.symbolic.split('=')
+                if isinstance(eq.symbolic, str) and "=" in eq.symbolic:
+                    sides = eq.symbolic.split("=")
                     lhs = sp.sympify(sides[0].strip())
                     rhs = sp.sympify(sides[1].strip())
                     # Substitute the solution values into both sides
                     lhs_val = lhs.subs(quiz.solution.symbolic)
                     rhs_val = rhs.subs(quiz.solution.symbolic)
                     # Verify that the equation is satisfied
-                    assert abs(float(lhs_val) - float(rhs_val)) < 1e-10, f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                    assert abs(float(lhs_val) - float(rhs_val)) < 1e-10, (
+                        f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                    )
                 else:
                     # If the equation is a SymPy equation, substitute the solution values
                     if eq.symbolic is not None:
                         result = eq.symbolic.subs(quiz.solution.symbolic)
                         # Verify that the equation is satisfied
-                        assert bool(result), f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
-    
+                        assert bool(result), (
+                            f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                        )
+
     @pytest.mark.basic_math
     def test_basic_math_unique_solution(self, generator):
         """Test that basic math equations have exactly one solution."""
         quiz = generator.generate_basic_math()
-        
+
         # Extract the symbolic equation
         eq = quiz.equations[0]
-        
+
         # If the equation is a string with an equals sign, convert it to a SymPy equation
-        if isinstance(eq.symbolic, str) and '=' in eq.symbolic:
-            sides = eq.symbolic.split('=')
+        if isinstance(eq.symbolic, str) and "=" in eq.symbolic:
+            sides = eq.symbolic.split("=")
             lhs = sp.sympify(sides[0].strip())
             rhs = sp.sympify(sides[1].strip())
             symbolic_equation = sp.Eq(lhs, rhs)
         else:
             symbolic_equation = eq.symbolic
-        
+
         # Use SymPy to solve the equation
         if symbolic_equation is not None:
-            variable = sp.Symbol('x')
+            variable = sp.Symbol("x")
             solutions = sp.solve(symbolic_equation, variable)
-            
+
             # Check that there is exactly one solution
             assert len(solutions) == 1, f"Expected exactly one solution, got {len(solutions)}"
-            
+
             # Verify the solution matches the one provided by the generator
-            assert abs(float(solutions[0]) - float(quiz.solution.human_readable['x'])) < 1e-10, f"Solution mismatch: expected {quiz.solution.human_readable['x']}, got {solutions[0]}"
-    
+            assert abs(float(solutions[0]) - float(quiz.solution.human_readable["x"])) < 1e-10, (
+                f"Solution mismatch: expected {quiz.solution.human_readable['x']}, got {solutions[0]}"
+            )
+
     @pytest.mark.basic_math
     def test_basic_math_via_generate_equations(self, generator):
         """Test basic math generation via the generate_equations method."""
@@ -215,26 +235,26 @@ class TestEquationsGeneratorV2:
             "operations": ["+", "-"],
             "max_value": 20,
             "allow_decimals": False,
-            "elements": 3
+            "elements": 3,
         }
-        
+
         quiz = generator.generate_equations(config)
-        
+
         # Check that we have one equation
         assert len(quiz.equations) == 1
-        
+
         # Check that the equation has the expected format (x = ...)
         eq_str = quiz.equations[0].formatted
         assert eq_str.startswith("x =")
-        
+
         # Check that the solution exists and is correct
         assert "x" in quiz.solution.human_readable
-        
+
         # Verify the solution is correct by evaluating the equation
         x_value = quiz.solution.human_readable["x"]
         right_side = eq_str.split("=")[1].strip()
         assert x_value == eval(right_side)  # Safe to use eval here for testing
-    
+
     @pytest.mark.basic_math
     def test_basic_math_random_seed(self, generator):
         """Test that using the same random seed produces the same equations."""
@@ -245,81 +265,85 @@ class TestEquationsGeneratorV2:
             "max_value": 20,
             "allow_decimals": False,
             "elements": 3,
-            "random_seed": 12345
+            "random_seed": 12345,
         }
-        
+
         config2 = config1.copy()  # Same config with same seed
-        
+
         quiz1 = generator.generate_equations(config1)
         quiz2 = generator.generate_equations(config2)
-        
+
         # Check that the equations and solutions are identical
         assert quiz1.equations[0].formatted == quiz2.equations[0].formatted
         assert quiz1.solution.human_readable == quiz2.solution.human_readable
-        
+
         # Now change the seed and verify we get different equations
         config3 = config1.copy()
         config3["random_seed"] = 54321
-        
+
         quiz3 = generator.generate_equations(config3)
-        
+
         # The equations should be different with a different seed
         # Note: There's a small chance they could be the same by coincidence
-        assert quiz1.equations[0].formatted != quiz3.equations[0].formatted or \
-               quiz1.solution.human_readable != quiz3.solution.human_readable
-    
+        assert (
+            quiz1.equations[0].formatted != quiz3.equations[0].formatted
+            or quiz1.solution.human_readable != quiz3.solution.human_readable
+        )
+
     # Simple Quiz tests
     @pytest.mark.simple_quiz
     def test_simple_quiz_default_params(self, generator):
         """Test simple quiz generation with default parameters."""
         quiz = generator.generate_simple_quiz()
-        
+
         # Check that we have the correct number of equations (default is 2)
         assert len(quiz.equations) == 2
-        
+
         # Check that the solution exists and has the correct number of variables
         assert len(quiz.solution.human_readable) == 2
-        
+
         # Check that all variables in the solution are integers
         for var, value in quiz.solution.human_readable.items():
             assert isinstance(value, int), f"Variable {var} has non-integer value {value}"
-    
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_num_unknowns(self, generator):
         """Test simple quiz generation with different numbers of unknowns."""
         for num_unknowns in range(1, 4):  # Test with 1, 2, and 3 unknowns
             quiz = generator.generate_simple_quiz(num_unknowns=num_unknowns)
-            
+
             # Check that we have the correct number of equations
             assert len(quiz.equations) == num_unknowns
-            
+
             # Check that the solution has the correct number of variables
             assert len(quiz.solution.human_readable) == num_unknowns
-            
+
             # Check that all variables in the solution are integers
             for var, value in quiz.solution.human_readable.items():
                 assert isinstance(value, int), f"Variable {var} has non-integer value {value}"
-    
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_max_value(self, generator):
         """Test simple quiz generation with different max values."""
         max_value = 10
         quiz = generator.generate_simple_quiz(max_value=max_value)
-        
+
         # Check that all values in the solution are within the max value
         for var, value in quiz.solution.human_readable.items():
-            assert abs(value) <= max_value, f"Value {value} for variable {var} exceeds max value {max_value}"
-    
+            assert abs(value) <= max_value, (
+                f"Value {value} for variable {var} exceeds max value {max_value}"
+            )
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_variable_repetition(self, generator):
         """Test that simple quiz equations include variable repetition."""
         quiz = generator.generate_simple_quiz()
-        
+
         # Check that at least one equation has a repeated variable
         has_repetition = False
         for eq in quiz.equations:
             eq_str = eq.formatted
-            
+
             # Count occurrences of each variable in the equation
             for var in quiz.solution.human_readable.keys():
                 # Count how many times the variable appears in the equation
@@ -327,25 +351,25 @@ class TestEquationsGeneratorV2:
                 if count > 1:
                     has_repetition = True
                     break
-            
+
             if has_repetition:
                 break
-        
+
         assert has_repetition, "No equation has repeated variables"
-    
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_operations(self, generator):
         """Test that simple quiz equations only use + and - operations."""
         quiz = generator.generate_simple_quiz()
-        
+
         # Check that only + and - operations are used
         for eq in quiz.equations:
             eq_str = eq.formatted
-            
+
             # Check that * and / are not in the equation
             assert "*" not in eq_str, f"Equation {eq_str} contains multiplication"
             assert "/" not in eq_str, f"Equation {eq_str} contains division"
-    
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_solution_correctness(self, generator):
         """Test that the solutions provided are correct for simple quiz equations."""
@@ -355,106 +379,103 @@ class TestEquationsGeneratorV2:
             {"num_unknowns": 2, "max_value": 10},
             {"num_unknowns": 3, "max_value": 30},
         ]
-        
+
         for config in configurations:
             quiz = generator.generate_simple_quiz(**config)
-            
+
             # Check each equation
             for eq in quiz.equations:
                 # If the equation is a string with an equals sign, convert it to a SymPy equation
-                if isinstance(eq.symbolic, str) and '=' in eq.symbolic:
-                    sides = eq.symbolic.split('=')
+                if isinstance(eq.symbolic, str) and "=" in eq.symbolic:
+                    sides = eq.symbolic.split("=")
                     lhs = sp.sympify(sides[0].strip())
                     rhs = sp.sympify(sides[1].strip())
                     # Substitute the solution values into both sides
                     lhs_val = lhs.subs(quiz.solution.symbolic)
                     rhs_val = rhs.subs(quiz.solution.symbolic)
                     # Verify that the equation is satisfied
-                    assert abs(float(lhs_val) - float(rhs_val)) < 1e-10, f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                    assert abs(float(lhs_val) - float(rhs_val)) < 1e-10, (
+                        f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                    )
                 else:
                     # If the equation is a SymPy equation, substitute the solution values
                     if eq.symbolic is not None:
                         result = eq.symbolic.subs(quiz.solution.symbolic)
                         # Verify that the equation is satisfied
-                        assert bool(result), f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
-    
+                        assert bool(result), (
+                            f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                        )
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_unique_solution(self, generator):
         """Test that simple quiz equations have exactly one solution."""
         quiz = generator.generate_simple_quiz()
-        
+
         # Extract the symbolic equations
         symbolic_equations = []
         for eq in quiz.equations:
             # If the equation is a string with an equals sign, convert it to a SymPy equation
-            if isinstance(eq.symbolic, str) and '=' in eq.symbolic:
-                sides = eq.symbolic.split('=')
+            if isinstance(eq.symbolic, str) and "=" in eq.symbolic:
+                sides = eq.symbolic.split("=")
                 lhs = sp.sympify(sides[0].strip())
                 rhs = sp.sympify(sides[1].strip())
                 symbolic_equations.append(sp.Eq(lhs, rhs))
             else:
                 symbolic_equations.append(eq.symbolic)
-        
+
         # Use SymPy to solve the system
         variables = [sp.Symbol(var) for var in quiz.solution.human_readable.keys()]
         solutions = sp.solve(symbolic_equations, variables, dict=True)
-        
+
         # Check that there is exactly one solution
         assert len(solutions) == 1, f"Expected exactly one solution, got {len(solutions)}"
-        
+
         # Verify the solution matches the one provided by the generator
         for var, value in quiz.solution.symbolic.items():
-            assert abs(float(solutions[0][var]) - float(value)) < 1e-10, f"Solution mismatch for {var}: expected {value}, got {solutions[0][var]}"
-    
+            assert abs(float(solutions[0][var]) - float(value)) < 1e-10, (
+                f"Solution mismatch for {var}: expected {value}, got {solutions[0][var]}"
+            )
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_via_generate_equations(self, generator):
         """Test simple quiz generation via the generate_equations method."""
-        config = {
-            "type": "simple_quiz",
-            "num_unknowns": 2,
-            "max_value": 20
-        }
-        
+        config = {"type": "simple_quiz", "num_unknowns": 2, "max_value": 20}
+
         quiz = generator.generate_equations(config)
-        
+
         # Check that we have the correct number of equations
         assert len(quiz.equations) == 2
-        
+
         # Check that the solution exists and has the correct number of variables
         assert len(quiz.solution.human_readable) == 2
-        
+
         # Check that all variables in the solution are integers
         for var, value in quiz.solution.human_readable.items():
             assert isinstance(value, int), f"Variable {var} has non-integer value {value}"
-    
+
     @pytest.mark.simple_quiz
     def test_simple_quiz_random_seed(self, generator):
         """Test that using the same random seed produces the same equations."""
         # This test is for the generate_equations method which accepts a random_seed parameter
-        config1 = {
-            "type": "simple_quiz",
-            "num_unknowns": 2,
-            "max_value": 20,
-            "random_seed": 12345
-        }
-        
+        config1 = {"type": "simple_quiz", "num_unknowns": 2, "max_value": 20, "random_seed": 12345}
+
         config2 = config1.copy()  # Same config with same seed
-        
+
         quiz1 = generator.generate_equations(config1)
         quiz2 = generator.generate_equations(config2)
-        
+
         # Check that the equations and solutions are identical
         for i in range(len(quiz1.equations)):
             assert quiz1.equations[i].formatted == quiz2.equations[i].formatted
-        
+
         assert quiz1.solution.human_readable == quiz2.solution.human_readable
-        
+
         # Now change the seed and verify we get different equations
         config3 = config1.copy()
         config3["random_seed"] = 54321
-        
+
         quiz3 = generator.generate_equations(config3)
-        
+
         # The equations should be different with a different seed
         # Note: There's a small chance they could be the same by coincidence
         different_equations = False
@@ -462,173 +483,196 @@ class TestEquationsGeneratorV2:
             if quiz1.equations[i].formatted != quiz3.equations[i].formatted:
                 different_equations = True
                 break
-        
+
         different_solutions = quiz1.solution.human_readable != quiz3.solution.human_readable
-        
+
         assert different_equations or different_solutions
-    
+
     # Grade School tests
     @pytest.mark.grade_school
     def test_grade_school_default_params(self, generator):
         """Test grade school equation generation with default parameters."""
         quiz = generator.generate_grade_school()
-        
+
         # Check that we have the correct number of equations (default is 2)
         assert len(quiz.equations) == 2
-        
+
         # Check that the solution exists and has the correct number of variables
         assert len(quiz.solution.human_readable) == 2
-    
+
     @pytest.mark.grade_school
     def test_grade_school_num_unknowns(self, generator):
         """Test grade school equation generation with different numbers of unknowns."""
         for num_unknowns in range(1, 4):  # Test with 1, 2, and 3 unknowns
             quiz = generator.generate_grade_school(num_unknowns=num_unknowns)
-            
+
             # Check that we have the correct number of equations
             assert len(quiz.equations) == num_unknowns
-            
+
             # Check that the solution has the correct number of variables
             assert len(quiz.solution.human_readable) == num_unknowns
-    
+
     @pytest.mark.grade_school
     def test_grade_school_operations(self, generator):
         """Test grade school equation generation with different operations."""
         # Test with different operation sets
-        operation_sets = [
-            ["+", "-"],
-            ["+", "-", "*"],
-            ["+", "-", "*", "/"]
-        ]
-        
+        operation_sets = [["+", "-"], ["+", "-", "*"], ["+", "-", "*", "/"]]
+
         for operations in operation_sets:
             quiz = generator.generate_grade_school(operations=operations)
-            
+
             # Check that only the specified operations are used
             for eq in quiz.equations:
                 eq_str = eq.formatted
-                
+
                 # Check that only the specified operations are in the equation
                 for op in ["+", "-", "*", "/"]:
                     if op in operations:
                         pass  # Operation is allowed
                     else:
-                        assert op not in eq_str, f"Operation {op} should not be in equation {eq_str}"
-    
+                        assert op not in eq_str, (
+                            f"Operation {op} should not be in equation {eq_str}"
+                        )
+
     @pytest.mark.grade_school
     def test_grade_school_max_value(self, generator):
         """Test grade school equation generation with different max values."""
         max_value = 10
         quiz = generator.generate_grade_school(max_value=max_value)
-        
+
         # Check that all constants in the equations are within the max value
         for eq in quiz.equations:
             eq_str = eq.formatted
-            
+
             # Extract the right side value (after the equals sign)
-            right_side = eq_str.split('=')[1].strip()
-            
+            right_side = eq_str.split("=")[1].strip()
+
             # Check if the right side is a number
             try:
                 right_side_value = float(right_side)
-                assert abs(right_side_value) <= max_value, f"Right side value {right_side_value} exceeds max value {max_value} in equation {eq_str}"
+                assert abs(right_side_value) <= max_value, (
+                    f"Right side value {right_side_value} exceeds max value {max_value} in equation {eq_str}"
+                )
             except ValueError:
                 # If the right side is not a simple number, we'll skip this check
                 pass
-            
+
             # Check that all coefficients are within the max value
             import re
+
             # Find all patterns like "5*x" where 5 is the coefficient
-            coefficients = re.findall(r'(\d+)\*', eq_str)
+            coefficients = re.findall(r"(\d+)\*", eq_str)
             for coef in coefficients:
-                assert int(coef) <= max_value, f"Coefficient {coef} exceeds max value {max_value} in equation {eq_str}"
-            
+                assert int(coef) <= max_value, (
+                    f"Coefficient {coef} exceeds max value {max_value} in equation {eq_str}"
+                )
+
             # Check that all standalone constants are within the max value
             # This regex finds numbers that are not part of a coefficient (not followed by *)
-            constants = re.findall(r'(?<!\d)\b(\d+)\b(?!\s*\*)', eq_str)
+            constants = re.findall(r"(?<!\d)\b(\d+)\b(?!\s*\*)", eq_str)
             for const in constants:
-                assert int(const) <= max_value, f"Constant {const} exceeds max value {max_value} in equation {eq_str}"
-    
+                assert int(const) <= max_value, (
+                    f"Constant {const} exceeds max value {max_value} in equation {eq_str}"
+                )
+
     @pytest.mark.grade_school
     def test_grade_school_allow_decimals(self, generator):
         """Test grade school equation generation with decimal values."""
         # Test with decimals not allowed
         quiz_without_decimals = generator.generate_grade_school(allow_decimals=False)
-        
+
         # Check that all values in the solution are integers
         for var, value in quiz_without_decimals.solution.human_readable.items():
             assert isinstance(value, int), f"Variable {var} has non-integer value {value}"
-        
+
         # Test with decimals allowed
         quiz_with_decimals = generator.generate_grade_school(allow_decimals=True)
-        
+
         # We can't guarantee decimals will be used, but we can check that the solution is correct
         # by verifying each equation is satisfied by the solution
         for eq in quiz_with_decimals.equations:
             if eq.symbolic is not None:
                 result = eq.symbolic.subs(quiz_with_decimals.solution.symbolic)
-                assert bool(result), f"Equation {eq.formatted} not satisfied by solution {quiz_with_decimals.solution.human_readable}"
-    
+                assert bool(result), (
+                    f"Equation {eq.formatted} not satisfied by solution {quiz_with_decimals.solution.human_readable}"
+                )
+
     @pytest.mark.grade_school
     def test_grade_school_solution_correctness(self, generator):
         """Test that the solutions provided are correct for grade school equations."""
         # Test with various configurations
         configurations = [
             {"num_unknowns": 1, "operations": ["+", "-"], "max_value": 20, "allow_decimals": False},
-            {"num_unknowns": 2, "operations": ["+", "-", "*"], "max_value": 10, "allow_decimals": False},
-            {"num_unknowns": 3, "operations": ["+", "-", "*", "/"], "max_value": 30, "allow_decimals": True},
+            {
+                "num_unknowns": 2,
+                "operations": ["+", "-", "*"],
+                "max_value": 10,
+                "allow_decimals": False,
+            },
+            {
+                "num_unknowns": 3,
+                "operations": ["+", "-", "*", "/"],
+                "max_value": 30,
+                "allow_decimals": True,
+            },
         ]
-        
+
         for config in configurations:
             quiz = generator.generate_grade_school(**config)
-            
+
             # Check each equation
             for eq in quiz.equations:
                 # If the equation is a string with an equals sign, convert it to a SymPy equation
-                if isinstance(eq.symbolic, str) and '=' in eq.symbolic:
-                    sides = eq.symbolic.split('=')
+                if isinstance(eq.symbolic, str) and "=" in eq.symbolic:
+                    sides = eq.symbolic.split("=")
                     lhs = sp.sympify(sides[0].strip())
                     rhs = sp.sympify(sides[1].strip())
                     # Substitute the solution values into both sides
                     lhs_val = lhs.subs(quiz.solution.symbolic)
                     rhs_val = rhs.subs(quiz.solution.symbolic)
                     # Verify that the equation is satisfied
-                    assert abs(float(lhs_val) - float(rhs_val)) < 1e-10, f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                    assert abs(float(lhs_val) - float(rhs_val)) < 1e-10, (
+                        f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                    )
                 else:
                     # If the equation is a SymPy equation, substitute the solution values
                     if eq.symbolic is not None:
                         result = eq.symbolic.subs(quiz.solution.symbolic)
                         # Verify that the equation is satisfied
-                        assert bool(result), f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
-    
+                        assert bool(result), (
+                            f"Equation {eq.formatted} not satisfied by solution {quiz.solution.human_readable}"
+                        )
+
     @pytest.mark.grade_school
     def test_grade_school_unique_solution(self, generator):
         """Test that grade school equations have exactly one solution."""
         quiz = generator.generate_grade_school(num_unknowns=2)  # Test with 2 unknowns
-        
+
         # Extract the symbolic equations
         symbolic_equations = []
         for eq in quiz.equations:
             # If the equation is a string with an equals sign, convert it to a SymPy equation
-            if isinstance(eq.symbolic, str) and '=' in eq.symbolic:
-                sides = eq.symbolic.split('=')
+            if isinstance(eq.symbolic, str) and "=" in eq.symbolic:
+                sides = eq.symbolic.split("=")
                 lhs = sp.sympify(sides[0].strip())
                 rhs = sp.sympify(sides[1].strip())
                 symbolic_equations.append(sp.Eq(lhs, rhs))
             else:
                 symbolic_equations.append(eq.symbolic)
-        
+
         # Use SymPy to solve the system
         variables = [sp.Symbol(var) for var in quiz.solution.human_readable.keys()]
         solutions = sp.solve(symbolic_equations, variables, dict=True)
-        
+
         # Check that there is exactly one solution
         assert len(solutions) == 1, f"Expected exactly one solution, got {len(solutions)}"
-        
+
         # Verify the solution matches the one provided by the generator
         for var, value in quiz.solution.symbolic.items():
-            assert abs(float(solutions[0][var]) - float(value)) < 1e-10, f"Solution mismatch for {var}: expected {value}, got {solutions[0][var]}"
-    
+            assert abs(float(solutions[0][var]) - float(value)) < 1e-10, (
+                f"Solution mismatch for {var}: expected {value}, got {solutions[0][var]}"
+            )
+
     @pytest.mark.grade_school
     def test_grade_school_via_generate_equations(self, generator):
         """Test grade school equation generation via the generate_equations method."""
@@ -637,21 +681,21 @@ class TestEquationsGeneratorV2:
             "num_unknowns": 2,
             "operations": ["+", "-", "*"],
             "max_value": 20,
-            "allow_decimals": False
+            "allow_decimals": False,
         }
-        
+
         quiz = generator.generate_equations(config)
-        
+
         # Check that we have the correct number of equations
         assert len(quiz.equations) == 2
-        
+
         # Check that the solution exists and has the correct number of variables
         assert len(quiz.solution.human_readable) == 2
-        
+
         # Check that all values in the solution are integers (since allow_decimals is False)
         for var, value in quiz.solution.human_readable.items():
             assert isinstance(value, int), f"Variable {var} has non-integer value {value}"
-    
+
     @pytest.mark.grade_school
     def test_grade_school_random_seed(self, generator):
         """Test that using the same random seed produces the same equations."""
@@ -662,26 +706,26 @@ class TestEquationsGeneratorV2:
             "operations": ["+", "-"],
             "max_value": 20,
             "allow_decimals": False,
-            "random_seed": 12345
+            "random_seed": 12345,
         }
-        
+
         config2 = config1.copy()  # Same config with same seed
-        
+
         quiz1 = generator.generate_equations(config1)
         quiz2 = generator.generate_equations(config2)
-        
+
         # Check that the equations and solutions are identical
         for i in range(len(quiz1.equations)):
             assert quiz1.equations[i].formatted == quiz2.equations[i].formatted
-        
+
         assert quiz1.solution.human_readable == quiz2.solution.human_readable
-        
+
         # Now change the seed and verify we get different equations
         config3 = config1.copy()
         config3["random_seed"] = 54321
-        
+
         quiz3 = generator.generate_equations(config3)
-        
+
         # The equations should be different with a different seed
         # Note: There's a small chance they could be the same by coincidence
         different_equations = False
@@ -689,7 +733,7 @@ class TestEquationsGeneratorV2:
             if quiz1.equations[i].formatted != quiz3.equations[i].formatted:
                 different_equations = True
                 break
-        
+
         different_solutions = quiz1.solution.human_readable != quiz3.solution.human_readable
-        
+
         assert different_equations or different_solutions

--- a/tests/unit/test_pokemon_catching.py
+++ b/tests/unit/test_pokemon_catching.py
@@ -3,25 +3,24 @@ Unit tests for Pokémon catching functionality.
 """
 
 
-
 def test_catch_pokemon(mock_session_manager):
     """Test catching a Pokémon and incrementing its count."""
     # Use the mock session manager from fixtures
     session_manager = mock_session_manager
-    
+
     # Reset state to ensure clean test
     session_manager.state.caught_pokemon = {}
-    
+
     # Catch a Pokémon for the first time
     count = session_manager.catch_pokemon("pikachu")
-    
+
     # Check that the Pokémon was caught
     assert count == 1
     assert session_manager.state.caught_pokemon["pikachu"] == 1
-    
+
     # Catch the same Pokémon again
     count = session_manager.catch_pokemon("pikachu")
-    
+
     # Check that the count was incremented
     assert count == 2
     assert session_manager.state.caught_pokemon["pikachu"] == 2
@@ -31,15 +30,12 @@ def test_get_caught_pokemon(mock_session_manager):
     """Test getting the caught Pokémon dictionary."""
     # Use the mock session manager from fixtures
     session_manager = mock_session_manager
-    
+
     # Reset state to ensure clean test
-    session_manager.state.caught_pokemon = {
-        "pikachu": 2,
-        "bulbasaur": 1
-    }
-    
+    session_manager.state.caught_pokemon = {"pikachu": 2, "bulbasaur": 1}
+
     # Get caught Pokémon
     caught_pokemon = session_manager.get_caught_pokemon()
-    
+
     # Check that the caught Pokémon dictionary is correct
-    assert caught_pokemon == {"pikachu": 2, "bulbasaur": 1} 
+    assert caught_pokemon == {"pikachu": 2, "bulbasaur": 1}

--- a/tests/unit/test_pokemon_selector.py
+++ b/tests/unit/test_pokemon_selector.py
@@ -14,19 +14,19 @@ def test_get_eligible_tiers():
     # Level 1-10 should only have tier 1
     assert PokemonSelector.get_eligible_tiers(1) == [1]
     assert PokemonSelector.get_eligible_tiers(10) == [1]
-    
+
     # Level 11-20 should have tiers 1-2
     assert PokemonSelector.get_eligible_tiers(11) == [1, 2]
     assert PokemonSelector.get_eligible_tiers(20) == [1, 2]
-    
+
     # Level 21-30 should have tiers 1-3
     assert PokemonSelector.get_eligible_tiers(21) == [1, 2, 3]
     assert PokemonSelector.get_eligible_tiers(30) == [1, 2, 3]
-    
+
     # Level 31-40 should have tiers 1-4
     assert PokemonSelector.get_eligible_tiers(31) == [1, 2, 3, 4]
     assert PokemonSelector.get_eligible_tiers(40) == [1, 2, 3, 4]
-    
+
     # Level 41+ should have all tiers
     assert PokemonSelector.get_eligible_tiers(41) == [1, 2, 3, 4, 5]
     assert PokemonSelector.get_eligible_tiers(50) == [1, 2, 3, 4, 5]
@@ -40,30 +40,37 @@ def test_calculate_adjusted_weight():
     assert PokemonSelector.calculate_adjusted_weight(1, 7, 1) == base_weight_tier1
     assert PokemonSelector.calculate_adjusted_weight(1, 1, 50) == base_weight_tier1
     assert PokemonSelector.calculate_adjusted_weight(1, 7, 50) == base_weight_tier1
-    
+
     # For higher tiers, test relative weights rather than specific values
-    
+
     # 1. Difficulty effect: Higher difficulty should increase weight for higher tiers
     for tier in range(2, 6):
         if tier in TIER_BASE_WEIGHTS:
             low_difficulty_weight = PokemonSelector.calculate_adjusted_weight(tier, 1, 10)
             high_difficulty_weight = PokemonSelector.calculate_adjusted_weight(tier, 7, 10)
-            assert high_difficulty_weight > low_difficulty_weight, f"Tier {tier} weight should increase with difficulty"
-    
+            assert high_difficulty_weight > low_difficulty_weight, (
+                f"Tier {tier} weight should increase with difficulty"
+            )
+
     # 2. Level effect: Higher player level should increase weight for higher tiers
     for tier in range(2, 6):
         if tier in TIER_BASE_WEIGHTS:
             low_level_weight = PokemonSelector.calculate_adjusted_weight(tier, 4, 10)
             high_level_weight = PokemonSelector.calculate_adjusted_weight(tier, 4, 50)
-            assert high_level_weight > low_level_weight, f"Tier {tier} weight should increase with player level"
-    
+            assert high_level_weight > low_level_weight, (
+                f"Tier {tier} weight should increase with player level"
+            )
+
     # 3. Tier effect: Higher tiers should have higher weights at high difficulty/level
     weights_at_high_settings = [
-        PokemonSelector.calculate_adjusted_weight(tier, 7, 50) 
-        for tier in range(1, 6) if tier in TIER_BASE_WEIGHTS
+        PokemonSelector.calculate_adjusted_weight(tier, 7, 50)
+        for tier in range(1, 6)
+        if tier in TIER_BASE_WEIGHTS
     ]
     for i in range(1, len(weights_at_high_settings)):
-        assert weights_at_high_settings[i] > weights_at_high_settings[i-1], "Higher tiers should have higher weights at high difficulty/level"
+        assert weights_at_high_settings[i] > weights_at_high_settings[i - 1], (
+            "Higher tiers should have higher weights at high difficulty/level"
+        )
 
 
 def test_select_pokemon():
@@ -74,24 +81,24 @@ def test_select_pokemon():
         "bulbasaur": Pokemon(name="Bulbasaur", image_path="bulbasaur.png", tier=2),
         "rattata": Pokemon(name="Rattata", image_path="rattata.png", tier=1),
         "mewtwo": Pokemon(name="Mewtwo", image_path="mewtwo.png", tier=5),
-        "charizard": Pokemon(name="Charizard", image_path="charizard.png", tier=3)
+        "charizard": Pokemon(name="Charizard", image_path="charizard.png", tier=3),
     }
-    
+
     # Test with level 1 (only tier 1 available)
     selected = PokemonSelector.select_pokemon(pokemons, player_level=1, difficulty=1, count=1)
     assert len(selected) == 1
     assert selected[0] == "rattata"  # Only tier 1 Pokémon
-    
+
     # Test with level 15 (tiers 1-2 available)
     selected = PokemonSelector.select_pokemon(pokemons, player_level=15, difficulty=1, count=3)
     assert len(selected) == 3
     for pokemon in selected:
         assert pokemon in ["rattata", "pikachu", "bulbasaur"]
-    
+
     # Test with level 50 (all tiers available)
     selected = PokemonSelector.select_pokemon(pokemons, player_level=50, difficulty=1, count=5)
     assert len(selected) == 5  # Should select all 5 Pokémon
-    
+
     # Test with empty Pokémon list
     selected = PokemonSelector.select_pokemon({}, player_level=1, difficulty=1, count=1)
     assert len(selected) == 0
@@ -102,25 +109,26 @@ def test_select_pokemon_with_weights():
     # Create a set of test Pokémon with tiers that will be eligible at level 50
     pokemons = {
         "rattata": Pokemon(name="Rattata", image_path="rattata.png", tier=1),
-        "pikachu": Pokemon(name="Pikachu", image_path="pikachu.png", tier=2)
+        "pikachu": Pokemon(name="Pikachu", image_path="pikachu.png", tier=2),
     }
-    
+
     # Test that weights are passed correctly to random.choices
     with pytest.MonkeyPatch.context() as mp:
         # Create a mock for random.choices that captures the weights parameter
         captured_weights = []
+
         def mock_choices(population, weights, k):
             captured_weights.append(weights)
             return [population[0]] * k
-        
+
         mp.setattr("random.choices", mock_choices)
-        
+
         # Call select_pokemon and verify weights were passed
         PokemonSelector.select_pokemon(pokemons, player_level=20, difficulty=3, count=1)
-        
+
         # Verify that weights were passed to random.choices
         assert len(captured_weights) == 1
         assert len(captured_weights[0]) == 2  # Two Pokémon, two weights
-        
+
         # Verify that weights are non-negative
-        assert all(w > 0 for w in captured_weights[0]), "All weights should be positive" 
+        assert all(w > 0 for w in captured_weights[0]), "All weights should be positive"

--- a/tests/unit/test_pokemon_tier.py
+++ b/tests/unit/test_pokemon_tier.py
@@ -1,6 +1,7 @@
 """
 Unit tests for Pokemon tier assignment.
 """
+
 import json
 import tempfile
 from pathlib import Path
@@ -23,24 +24,18 @@ def test_pokemon_tier_custom():
 def test_load_pokemon_config_with_tiers():
     """Test loading Pokemon config with the new tier format."""
     # Create a temporary JSON file with Pokemon tiers in the new format
-    with tempfile.NamedTemporaryFile(mode='w+', suffix='.json', delete=False) as temp_file:
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as temp_file:
         json_data = {
             "pokemons": {
-                "pikachu": {
-                    "image_path": "pikachu.png"
-                },
-                "mew": {
-                    "image_path": "mew.png"
-                },
-                "rattata": {
-                    "image_path": "rattata.png"
-                }
+                "pikachu": {"image_path": "pikachu.png"},
+                "mew": {"image_path": "mew.png"},
+                "rattata": {"image_path": "rattata.png"},
             },
             "tiers": {
                 "2": ["pikachu"],
-                "5": ["mew"]
+                "5": ["mew"],
                 # rattata not in any tier, should default to 1
-            }
+            },
         }
         json.dump(json_data, temp_file)
         temp_file_path = temp_file.name
@@ -55,4 +50,4 @@ def test_load_pokemon_config_with_tiers():
         assert pokemons["rattata"].tier == 1  # Default tier
     finally:
         # Clean up the temporary file
-        Path(temp_file_path).unlink() 
+        Path(temp_file_path).unlink()

--- a/tests/unit/test_progression_manager.py
+++ b/tests/unit/test_progression_manager.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the ProgressionManager class.
 """
+
 from unittest.mock import MagicMock
 
 from src.app.game.game_config import GameConfig, Pokemon
@@ -13,18 +14,18 @@ def test_calculate_xp_needed():
     # Test XP needed for various levels
     assert ProgressionManager.calculate_xp_needed(1) == BASE_XP
     assert ProgressionManager.calculate_xp_needed(2) == int(BASE_XP * XP_MULTIPLIER)
-    assert ProgressionManager.calculate_xp_needed(10) == int(BASE_XP * (XP_MULTIPLIER ** 9))
+    assert ProgressionManager.calculate_xp_needed(10) == int(BASE_XP * (XP_MULTIPLIER**9))
 
 
 def test_xp_progression_curve():
     """Test the XP progression curve from Level 1 to 50."""
     # Calculate XP needed for each level
     xp_per_level = [ProgressionManager.calculate_xp_needed(level) for level in range(1, 51)]
-    
+
     # Check that XP requirements increase with level
     for i in range(1, len(xp_per_level)):
-        assert xp_per_level[i] > xp_per_level[i-1]
-    
+        assert xp_per_level[i] > xp_per_level[i - 1]
+
     # Check that the progression is reasonable
     # Level 10 should require less than 10x the XP of Level 1
     assert xp_per_level[9] < 10 * xp_per_level[0]
@@ -38,12 +39,12 @@ def test_calculate_xp_reward():
     pokemons = {
         "pikachu": Pokemon(name="Pikachu", image_path="pikachu.png", tier=2),
         "rattata": Pokemon(name="Rattata", image_path="rattata.png", tier=1),
-        "mewtwo": Pokemon(name="Mewtwo", image_path="mewtwo.png", tier=5)
+        "mewtwo": Pokemon(name="Mewtwo", image_path="mewtwo.png", tier=5),
     }
-    
+
     mock_game_config = MagicMock(spec=GameConfig)
     mock_game_config.pokemons = pokemons
-    
+
     # Calculate XP reward for catching Pokémon of different tiers
     # Tier 1 (rattata) = 50 XP
     # Tier 2 (pikachu) = 100 XP
@@ -51,34 +52,24 @@ def test_calculate_xp_reward():
     # Difficulty 3 bonus = 100 * 3 = 300 XP
     # Total = 50 + 100 + 800 + 300 = 1250 XP
     xp_reward = ProgressionManager.calculate_xp_reward(
-        ["rattata", "pikachu", "mewtwo"],
-        3,
-        mock_game_config
+        ["rattata", "pikachu", "mewtwo"], 3, mock_game_config
     )
-    
+
     # Check that the XP reward is correct
     assert xp_reward == 1250
-    
+
     # Test with unknown Pokémon (should be ignored)
-    xp_reward = ProgressionManager.calculate_xp_reward(
-        ["unknown", "pikachu"],
-        1,
-        mock_game_config
-    )
-    
+    xp_reward = ProgressionManager.calculate_xp_reward(["unknown", "pikachu"], 1, mock_game_config)
+
     # Check that only the known Pokémon and difficulty bonus are counted
     # Tier 2 (pikachu) = 100 XP
     # Difficulty 1 bonus = 100 * 1 = 100 XP
     # Total = 100 + 100 = 200 XP
     assert xp_reward == 200
-    
+
     # Test with empty caught Pokémon list (only difficulty bonus)
-    xp_reward = ProgressionManager.calculate_xp_reward(
-        [],
-        2,
-        mock_game_config
-    )
-    
+    xp_reward = ProgressionManager.calculate_xp_reward([], 2, mock_game_config)
+
     # Check that only the difficulty bonus is counted
     # Difficulty 2 bonus = 100 * 2 = 200 XP
     assert xp_reward == 200
@@ -88,37 +79,37 @@ def test_process_level_up():
     """Test processing level-up logic."""
     # Test with no level up
     result = ProgressionManager.process_level_up(1, 50)
-    assert result['level'] == 1
-    assert result['xp'] == 50
-    assert result['leveled_up'] is False
-    
+    assert result["level"] == 1
+    assert result["xp"] == 50
+    assert result["leveled_up"] is False
+
     # Test with one level up
     result = ProgressionManager.process_level_up(1, BASE_XP + 50)
-    assert result['level'] == 2
-    assert result['xp'] == 50
-    assert result['leveled_up'] is True
-    
+    assert result["level"] == 2
+    assert result["xp"] == 50
+    assert result["leveled_up"] is True
+
     # Test with multiple level ups
     # Level 1 needs BASE_XP
     # Level 2 needs BASE_XP * XP_MULTIPLIER
     # Total XP for 2 level ups = BASE_XP + BASE_XP * XP_MULTIPLIER + 25
     total_xp = BASE_XP + int(BASE_XP * XP_MULTIPLIER) + 25
     result = ProgressionManager.process_level_up(1, total_xp)
-    assert result['level'] == 3
-    assert result['xp'] == 25
-    assert result['leveled_up'] is True
+    assert result["level"] == 3
+    assert result["xp"] == 25
+    assert result["leveled_up"] is True
 
 
 def test_get_level_info():
     """Test getting level information."""
     # Test level info for level 1
     level_info = ProgressionManager.get_level_info(1, 50)
-    assert level_info['level'] == 1
-    assert level_info['xp'] == 50
-    assert level_info['xp_needed'] == BASE_XP
-    
+    assert level_info["level"] == 1
+    assert level_info["xp"] == 50
+    assert level_info["xp_needed"] == BASE_XP
+
     # Test level info for level 10
     level_info = ProgressionManager.get_level_info(10, 500)
-    assert level_info['level'] == 10
-    assert level_info['xp'] == 500
-    assert level_info['xp_needed'] == int(BASE_XP * (XP_MULTIPLIER ** 9)) 
+    assert level_info["level"] == 10
+    assert level_info["xp"] == 500
+    assert level_info["xp_needed"] == int(BASE_XP * (XP_MULTIPLIER**9))

--- a/tests/unit/test_progression_simulation.py
+++ b/tests/unit/test_progression_simulation.py
@@ -1,6 +1,7 @@
 """
 Test script to simulate player progression from Level 1 to 50.
 """
+
 from unittest.mock import MagicMock
 
 from src.app.game.game_config import GameConfig, Pokemon
@@ -13,15 +14,15 @@ def test_xp_progression_curve():
     """Test the XP progression curve from Level 1 to 50."""
     # Calculate XP needed for each level
     xp_per_level = [ProgressionManager.calculate_xp_needed(level) for level in range(1, 51)]
-    
+
     # Print XP needed for each level
     for level, xp in enumerate(xp_per_level, 1):
         print(f"Level {level}: {xp} XP")
-    
+
     # Check that XP requirements increase with level
     for i in range(1, len(xp_per_level)):
-        assert xp_per_level[i] > xp_per_level[i-1]
-    
+        assert xp_per_level[i] > xp_per_level[i - 1]
+
     # Check that the progression is reasonable
     # Level 10 should require less than 10x the XP of Level 1
     assert xp_per_level[9] < 10 * xp_per_level[0]
@@ -31,80 +32,96 @@ def test_xp_progression_curve():
 
 def test_pokemon_tier_distribution():
     """Test the distribution of Pokémon tiers at different player levels and difficulties."""
-    
+
     # Create a set of test Pokémon
     pokemons = {
-        f"pokemon_{i}": Pokemon(name=f"Pokemon {i}", image_path=f"pokemon_{i}.png", tier=(i % 5) + 1)
+        f"pokemon_{i}": Pokemon(
+            name=f"Pokemon {i}", image_path=f"pokemon_{i}.png", tier=(i % 5) + 1
+        )
         for i in range(100)  # Create 100 Pokémon with tiers 1-5
     }
-    
+
     # Test tier distribution at different player levels
     levels_to_test = [1, 10, 20, 30, 40, 50]
-    
+
     for level in levels_to_test:
         eligible_tiers = PokemonSelector.get_eligible_tiers(level)
         print(f"Level {level}: Eligible tiers {eligible_tiers}")
-        
+
         # Test with a moderate difficulty
         difficulty = 4
-        
+
         # Select Pokémon to get a distribution
         selected = []
         for _ in range(5):  # Run 5 times to get 500 Pokémon
             selected.extend(PokemonSelector.select_pokemon(pokemons, level, difficulty, count=100))
-        
+
         # Count the tiers of selected Pokémon
         tier_counts = {}
         for pokemon_id in selected:
             tier = pokemons[pokemon_id].tier
             tier_counts[tier] = tier_counts.get(tier, 0) + 1
-        
+
         # Print the distribution
         total = sum(tier_counts.values())
-        print(f"  Difficulty {difficulty}: {', '.join([f'Tier {t}: {c} ({c/total:.1%})' for t, c in sorted(tier_counts.items())])}")
-        
+        print(
+            f"  Difficulty {difficulty}: {', '.join([f'Tier {t}: {c} ({c / total:.1%})' for t, c in sorted(tier_counts.items())])}"
+        )
+
         # Check that only eligible tiers are selected
         for tier in tier_counts:
             assert tier in eligible_tiers
-        
+
         # Check that all eligible tiers are represented (unless there's only one tier)
         if len(eligible_tiers) > 1:
             # Allow for some randomness - at least 80% of eligible tiers should be represented
             min_tiers_to_represent = max(1, int(0.8 * len(eligible_tiers)))
-            assert len(tier_counts) >= min_tiers_to_represent, f"Expected at least {min_tiers_to_represent} tiers to be represented, got {len(tier_counts)}"
-        
+            assert len(tier_counts) >= min_tiers_to_represent, (
+                f"Expected at least {min_tiers_to_represent} tiers to be represented, got {len(tier_counts)}"
+            )
+
         # If there are multiple tiers, higher tiers should have some representation
         if len(eligible_tiers) > 1:
             highest_eligible_tier = max(eligible_tiers)
             # For levels with multiple tiers, the highest tier should have some representation
             # unless it's a very high tier that might be rare
             if highest_eligible_tier <= 3 or level >= 40:  # Adjust based on your tier distribution
-                assert highest_eligible_tier in tier_counts, f"Highest eligible tier {highest_eligible_tier} should be represented"
+                assert highest_eligible_tier in tier_counts, (
+                    f"Highest eligible tier {highest_eligible_tier} should be represented"
+                )
 
 
 def test_xp_rewards():
     """Test XP rewards for catching Pokémon and completing adventures."""
     # Create a mock game config with Pokémon of different tiers
     pokemons = {
-        f"pokemon_{tier}": Pokemon(name=f"Pokemon {tier}", image_path=f"pokemon_{tier}.png", tier=tier)
+        f"pokemon_{tier}": Pokemon(
+            name=f"Pokemon {tier}", image_path=f"pokemon_{tier}.png", tier=tier
+        )
         for tier in range(1, 6)  # Create 5 Pokémon with tiers 1-5
     }
-    
+
     mock_game_config = MagicMock(spec=GameConfig)
     mock_game_config.pokemons = pokemons
-    
+
     # Test XP rewards for different combinations of caught Pokémon and difficulties
     test_cases = [
         # (caught_pokemon, difficulty, expected_xp)
         (["pokemon_1"], 1, TIER_XP_REWARDS[1] + 100),  # Tier 1, Difficulty 1
         (["pokemon_5"], 1, TIER_XP_REWARDS[5] + 100),  # Tier 5, Difficulty 1
-        (["pokemon_1", "pokemon_2", "pokemon_3"], 3, TIER_XP_REWARDS[1] + TIER_XP_REWARDS[2] + TIER_XP_REWARDS[3] + 300),  # Mixed tiers, Difficulty 3
+        (
+            ["pokemon_1", "pokemon_2", "pokemon_3"],
+            3,
+            TIER_XP_REWARDS[1] + TIER_XP_REWARDS[2] + TIER_XP_REWARDS[3] + 300,
+        ),  # Mixed tiers, Difficulty 3
         ([], 7, 700),  # No Pokémon, Difficulty 7 (only bonus XP)
     ]
-    
+
     for caught_pokemon, difficulty, expected_xp in test_cases:
         # Calculate XP reward using ProgressionManager
-        xp_reward = ProgressionManager.calculate_xp_reward(caught_pokemon, difficulty, mock_game_config)
-        
+        xp_reward = ProgressionManager.calculate_xp_reward(
+            caught_pokemon, difficulty, mock_game_config
+        )
+
         # Check that the XP reward is correct
-        assert xp_reward == expected_xp 
+        assert xp_reward == expected_xp

--- a/tests/unit/test_quiz_data.py
+++ b/tests/unit/test_quiz_data.py
@@ -21,15 +21,18 @@ from src.app.game.game_config import (
 
 @pytest.fixture
 def test_data_path():
-    return Path('tests/data/quizzes.json')
+    return Path("tests/data/quizzes.json")
+
 
 @pytest.fixture
 def test_pokemon_data_path():
-    return Path('tests/data/pokemons.json')
+    return Path("tests/data/pokemons.json")
+
 
 @pytest.fixture
 def quiz_data(test_data_path, test_pokemon_data_path):
     return load_game_config(test_data_path, test_pokemon_data_path)
+
 
 def test_load_quiz_data_structure(quiz_data):
     """Test if the quiz data is loaded with correct structure."""
@@ -38,92 +41,99 @@ def test_load_quiz_data_structure(quiz_data):
     assert isinstance(quiz_data.sections, list)
     assert isinstance(quiz_data.quizzes_by_id, dict)
 
+
 def test_pokemon_data_loading(quiz_data):
     """Test if Pokemon data is loaded correctly."""
     assert len(quiz_data.pokemons) == 4
-    pikachu = quiz_data.pokemons['pikachu']
+    pikachu = quiz_data.pokemons["pikachu"]
     assert isinstance(pikachu, Pokemon)
-    assert pikachu.name == 'pikachu'
-    assert pikachu.image_path == 'pikachu.png'
+    assert pikachu.name == "pikachu"
+    assert pikachu.image_path == "pikachu.png"
     assert pikachu.tier == 2  # Check tier value
-    
+
     # Check other Pokémon
-    assert 'bulbasaur' in quiz_data.pokemons
-    assert 'charmander' in quiz_data.pokemons
-    assert 'squirtle' in quiz_data.pokemons
+    assert "bulbasaur" in quiz_data.pokemons
+    assert "charmander" in quiz_data.pokemons
+    assert "squirtle" in quiz_data.pokemons
+
 
 def test_load_pokemon_config_function(test_pokemon_data_path):
     """Test if the load_pokemon_config function works correctly."""
     pokemons = load_pokemon_config(test_pokemon_data_path)
     assert len(pokemons) == 4
-    assert isinstance(pokemons['pikachu'], Pokemon)
-    assert pokemons['pikachu'].name == 'pikachu'
-    assert pokemons['pikachu'].image_path == 'pikachu.png'
-    assert pokemons['pikachu'].tier == 2
+    assert isinstance(pokemons["pikachu"], Pokemon)
+    assert pokemons["pikachu"].name == "pikachu"
+    assert pokemons["pikachu"].image_path == "pikachu.png"
+    assert pokemons["pikachu"].tier == 2
+
 
 def test_section_structure(quiz_data):
     """Test if sections are structured correctly."""
     assert len(quiz_data.sections) == 1
     section = quiz_data.sections[0]
-    
+
     assert isinstance(section, Section)
-    assert section.id == 'test_section'
-    assert section.title == 'Test Section'
-    assert section.description == 'Section for testing'
+    assert section.id == "test_section"
+    assert section.title == "Test Section"
+    assert section.description == "Section for testing"
     assert isinstance(section.quizzes, list)
     assert len(section.quizzes) == 2
-    
+
     # Check if all quizzes in section are properly structured
     for quiz in section.quizzes:
         assert isinstance(quiz, Quiz)
         assert quiz.section_id == section.id
         assert quiz.section_title == section.title
 
+
 def test_quiz_content(quiz_data):
     """Test if quiz content is loaded correctly."""
     # Test basic quiz
-    basic_quiz = quiz_data.quizzes_by_id['test_basic']
-    assert basic_quiz.title == 'Basic Test Quiz'
+    basic_quiz = quiz_data.quizzes_by_id["test_basic"]
+    assert basic_quiz.title == "Basic Test Quiz"
     assert len(basic_quiz.equations) == 1
-    assert basic_quiz.equations[0] == '2 + {pikachu} = 5'
-    
+    assert basic_quiz.equations[0] == "2 + {pikachu} = 5"
+
     # Test variable quiz
-    var_quiz = quiz_data.quizzes_by_id['test_variables']
-    assert var_quiz.title == 'Variable Test Quiz'
+    var_quiz = quiz_data.quizzes_by_id["test_variables"]
+    assert var_quiz.title == "Variable Test Quiz"
     assert len(var_quiz.equations) == 2
-    assert '{x}' in var_quiz.equations[0]
-    assert '{y}' in var_quiz.equations[0]
-    assert '{z}' in var_quiz.equations[1]
+    assert "{x}" in var_quiz.equations[0]
+    assert "{y}" in var_quiz.equations[0]
+    assert "{z}" in var_quiz.equations[1]
+
 
 def test_quiz_answers(quiz_data):
     """Test if quiz answers are structured correctly."""
     # Test basic quiz answers
-    basic_quiz = quiz_data.quizzes_by_id['test_basic']
+    basic_quiz = quiz_data.quizzes_by_id["test_basic"]
     assert isinstance(basic_quiz.answer, QuizAnswer)
-    assert basic_quiz.answer.values == {'pikachu': 3}
-    
+    assert basic_quiz.answer.values == {"pikachu": 3}
+
     # Test variable quiz answers
-    var_quiz = quiz_data.quizzes_by_id['test_variables']
+    var_quiz = quiz_data.quizzes_by_id["test_variables"]
     assert isinstance(var_quiz.answer, QuizAnswer)
-    assert var_quiz.answer.values == {'x': 5, 'y': 5, 'z': 2}
+    assert var_quiz.answer.values == {"x": 5, "y": 5, "z": 2}
+
 
 def test_quiz_navigation(quiz_data):
     """Test if quiz navigation (next_quiz_id) is set up correctly."""
-    basic_quiz = quiz_data.quizzes_by_id['test_basic']
-    var_quiz = quiz_data.quizzes_by_id['test_variables']
-    
+    basic_quiz = quiz_data.quizzes_by_id["test_basic"]
+    var_quiz = quiz_data.quizzes_by_id["test_variables"]
+
     # Basic quiz should link to variable quiz
-    assert basic_quiz.next_quiz_id == 'test_variables'
+    assert basic_quiz.next_quiz_id == "test_variables"
     # Variable quiz should have no next quiz
     assert var_quiz.next_quiz_id is None
+
 
 def test_quiz_lookup(quiz_data):
     """Test if quizzes can be looked up by ID."""
     # Check if both quizzes are in the lookup dict
-    assert 'test_basic' in quiz_data.quizzes_by_id
-    assert 'test_variables' in quiz_data.quizzes_by_id
-    
+    assert "test_basic" in quiz_data.quizzes_by_id
+    assert "test_variables" in quiz_data.quizzes_by_id
+
     # Check if the objects are the same as in sections
     section_quizzes = {quiz.id: quiz for quiz in quiz_data.sections[0].quizzes}
-    assert quiz_data.quizzes_by_id['test_basic'] is section_quizzes['test_basic']
-    assert quiz_data.quizzes_by_id['test_variables'] is section_quizzes['test_variables'] 
+    assert quiz_data.quizzes_by_id["test_basic"] is section_quizzes["test_basic"]
+    assert quiz_data.quizzes_by_id["test_variables"] is section_quizzes["test_variables"]

--- a/tests/unit/test_quiz_engine.py
+++ b/tests/unit/test_quiz_engine.py
@@ -28,8 +28,9 @@ def sample_quiz():
         answer=QuizAnswer(values={"x": 5, "y": 5, "z": 2}),
         section_id="test_section",
         section_title="Test Section",
-        display_number=1
+        display_number=1,
     )
+
 
 @pytest.fixture
 def sample_pokemon():
@@ -38,30 +39,32 @@ def sample_pokemon():
         "pikachu": type("Pokemon", (), {"image_path": "pikachu.png"}),
         "bulbasaur": type("Pokemon", (), {"image_path": "bulbasaur.png"}),
         "charmander": type("Pokemon", (), {"image_path": "charmander.png"}),
-        "squirtle": type("Pokemon", (), {"image_path": "squirtle.png"})
+        "squirtle": type("Pokemon", (), {"image_path": "squirtle.png"}),
     }
+
 
 @pytest.fixture
 def mock_equation_generator():
     """Fixture providing a mock equation generator."""
     generator = MagicMock()
-    
+
     # Create a mock quiz result
     mock_quiz = MagicMock()
     mock_quiz.solution.human_readable = {"x": 5, "y": 10, "z": 15}
     mock_quiz.equations = []
-    
+
     # Add mock equations with formatted property
     eq1 = MagicMock()
     eq1.formatted = "{x} + {y} = 15"
     eq2 = MagicMock()
     eq2.formatted = "{y} - {z} = -5"
     mock_quiz.equations = [eq1, eq2]
-    
+
     # Set up the generator to return our mock quiz
     generator.generate_equations.return_value = mock_quiz
-    
+
     return generator
+
 
 @pytest.fixture
 def mock_game_config():
@@ -73,12 +76,13 @@ def mock_game_config():
         "bulbasaur": Pokemon(name="Bulbasaur", image_path="bulbasaur.png", tier=2),
         "charizard": Pokemon(name="Charizard", image_path="charizard.png", tier=3),
         "blastoise": Pokemon(name="Blastoise", image_path="blastoise.png", tier=4),
-        "mewtwo": Pokemon(name="Mewtwo", image_path="mewtwo.png", tier=5)
+        "mewtwo": Pokemon(name="Mewtwo", image_path="mewtwo.png", tier=5),
     }
-    
+
     config = MagicMock()
     config.pokemons = pokemons
     return config
+
 
 def test_check_quiz_answers(sample_quiz):
     """Test checking quiz answers."""
@@ -88,7 +92,7 @@ def test_check_quiz_answers(sample_quiz):
     assert all_correct
     assert all(correct_dict.values())
     assert all_answered
-    
+
     # Test with partially correct answers
     partial_answers = {"x": 5, "y": 4, "z": 2}
     all_correct, correct_dict, all_answered = check_quiz_answers(sample_quiz, partial_answers)
@@ -97,7 +101,7 @@ def test_check_quiz_answers(sample_quiz):
     assert not correct_dict["y"]
     assert correct_dict["z"]
     assert all_answered
-    
+
     # Test with missing answers
     missing_answers = {"x": 5, "y": 5}
     all_correct, correct_dict, all_answered = check_quiz_answers(sample_quiz, missing_answers)
@@ -107,21 +111,23 @@ def test_check_quiz_answers(sample_quiz):
     assert not correct_dict["z"]
     assert not all_answered
 
+
 def test_get_display_variables(sample_pokemon):
     """Test getting display variables."""
+
     # Create a mock game config
     class MockGameConfig:
         def __init__(self, pokemons):
             self.pokemons = pokemons
-    
+
     game_config = MockGameConfig(sample_pokemon)
-    
+
     # Test with no image mapping
     display_vars = get_display_variables(game_config)
     assert len(display_vars) == 4
     assert display_vars["pikachu"] == "pikachu.png"
     assert display_vars["bulbasaur"] == "bulbasaur.png"
-    
+
     # Test with image mapping
     image_mapping = {"x": "x.png", "y": "y.png"}
     display_vars = get_display_variables(game_config, image_mapping)
@@ -130,82 +136,79 @@ def test_get_display_variables(sample_pokemon):
     assert display_vars["y"] == "y.png"
     assert display_vars["pikachu"] == "pikachu.png"
 
+
 def test_generate_random_quiz_data_with_player_level(mock_game_config, mock_equation_generator):
     """Test that generate_random_quiz_data selects Pokemon based on player level."""
     # Test with player level 1 (should only get tier 1 Pokemon)
-    difficulty = {'name': 'Easy', 'level': 1, 'params': {'min_value': 1, 'max_value': 10}}
-    
-    with patch('src.app.game.pokemon_selector.PokemonSelector.select_pokemon') as mock_select:
+    difficulty = {"name": "Easy", "level": 1, "params": {"min_value": 1, "max_value": 10}}
+
+    with patch("src.app.game.pokemon_selector.PokemonSelector.select_pokemon") as mock_select:
         # Mock the select_pokemon method to return specific Pokemon
         mock_select.return_value = ["rattata", "pidgey"]
-        
+
         quiz_id, quiz_data = generate_random_quiz_data(
-            mock_game_config, 
-            difficulty, 
-            mock_equation_generator,
-            player_level=1
+            mock_game_config, difficulty, mock_equation_generator, player_level=1
         )
-        
+
         # Verify select_pokemon was called with correct parameters
         mock_select.assert_called_once_with(
-            mock_game_config.pokemons, 
+            mock_game_config.pokemons,
             1,  # player_level
             1,  # difficulty level
-            count=3  # number of variables in the quiz
+            count=3,  # number of variables in the quiz
         )
-        
+
         # Verify the quiz data structure
         assert quiz_id.startswith("random_")
-        assert quiz_data['title'] == "Random Easy Quiz"
-        assert len(quiz_data['equations']) == 2
-        assert quiz_data['solution'] == {'x': '5', 'y': '10', 'z': '15'}
-        assert len(quiz_data['image_mapping']) == 2  # Only 2 Pokemon were returned by mock
+        assert quiz_data["title"] == "Random Easy Quiz"
+        assert len(quiz_data["equations"]) == 2
+        assert quiz_data["solution"] == {"x": "5", "y": "10", "z": "15"}
+        assert len(quiz_data["image_mapping"]) == 2  # Only 2 Pokemon were returned by mock
+
 
 def test_generate_random_quiz_data_integration(mock_game_config, mock_equation_generator):
     """Integration test for generate_random_quiz_data with actual PokemonSelector."""
     # Test with different player levels
-    difficulty = {'name': 'Medium', 'level': 3, 'params': {'min_value': 1, 'max_value': 20}}
-    
+    difficulty = {"name": "Medium", "level": 3, "params": {"min_value": 1, "max_value": 20}}
+
     # Test with player level 1 (should only get tier 1 Pokemon)
     quiz_id, quiz_data = generate_random_quiz_data(
-        mock_game_config, 
-        difficulty, 
-        mock_equation_generator,
-        player_level=1
+        mock_game_config, difficulty, mock_equation_generator, player_level=1
     )
-    
+
     # Verify the quiz data structure
     assert quiz_id.startswith("random_")
-    assert quiz_data['title'] == "Random Medium Quiz"
-    
+    assert quiz_data["title"] == "Random Medium Quiz"
+
     # Check that all Pokemon in the image mapping are from tier 1
-    for _var, image_path in quiz_data['image_mapping'].items():
+    for _var, image_path in quiz_data["image_mapping"].items():
         # Find the Pokemon with this image path
         pokemon_name = None
         for name, pokemon in mock_game_config.pokemons.items():
             if pokemon.image_path == image_path:
                 pokemon_name = name
                 break
-        
+
         assert pokemon_name is not None, f"Could not find Pokemon with image path {image_path}"
-        assert mock_game_config.pokemons[pokemon_name].tier == 1, f"Expected tier 1 Pokemon, got {mock_game_config.pokemons[pokemon_name].tier}"
-    
+        assert mock_game_config.pokemons[pokemon_name].tier == 1, (
+            f"Expected tier 1 Pokemon, got {mock_game_config.pokemons[pokemon_name].tier}"
+        )
+
     # Test with player level 15 (should get tier 1-2 Pokemon)
     quiz_id, quiz_data = generate_random_quiz_data(
-        mock_game_config, 
-        difficulty, 
-        mock_equation_generator,
-        player_level=15
+        mock_game_config, difficulty, mock_equation_generator, player_level=15
     )
-    
+
     # Check that all Pokemon in the image mapping are from tier 1-2
-    for _var, image_path in quiz_data['image_mapping'].items():
+    for _var, image_path in quiz_data["image_mapping"].items():
         # Find the Pokemon with this image path
         pokemon_name = None
         for name, pokemon in mock_game_config.pokemons.items():
             if pokemon.image_path == image_path:
                 pokemon_name = name
                 break
-        
+
         assert pokemon_name is not None, f"Could not find Pokemon with image path {image_path}"
-        assert mock_game_config.pokemons[pokemon_name].tier <= 2, f"Expected tier 1-2 Pokemon, got {mock_game_config.pokemons[pokemon_name].tier}" 
+        assert mock_game_config.pokemons[pokemon_name].tier <= 2, (
+            f"Expected tier 1-2 Pokemon, got {mock_game_config.pokemons[pokemon_name].tier}"
+        )

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -59,21 +59,30 @@ def test_client_bucket_bound_does_not_evict_global_counter():
 
 
 def test_client_identifier_uses_forwarded_address_only_when_trusted():
-    assert client_identifier(
-        "10.0.0.1",
-        "203.0.113.9, 198.51.100.2",
-        trust_forwarded_for=True,
-    ) == "203.0.113.9"
-    assert client_identifier(
-        "10.0.0.1",
-        "203.0.113.9",
-        trust_forwarded_for=False,
-    ) == "10.0.0.1"
+    assert (
+        client_identifier(
+            "10.0.0.1",
+            "203.0.113.9, 198.51.100.2",
+            trust_forwarded_for=True,
+        )
+        == "203.0.113.9"
+    )
+    assert (
+        client_identifier(
+            "10.0.0.1",
+            "203.0.113.9",
+            trust_forwarded_for=False,
+        )
+        == "10.0.0.1"
+    )
 
 
 def test_client_identifier_ignores_invalid_addresses():
-    assert client_identifier(
-        "192.0.2.4",
-        "not-an-ip",
-        trust_forwarded_for=True,
-    ) == "192.0.2.4"
+    assert (
+        client_identifier(
+            "192.0.2.4",
+            "not-an-ip",
+            trust_forwarded_for=True,
+        )
+        == "192.0.2.4"
+    )

--- a/tests/unit/test_view_models.py
+++ b/tests/unit/test_view_models.py
@@ -19,16 +19,12 @@ def basic_quiz_view_model():
         title="Test Quiz",
         equations=["x + 10 = y", "x * z = 10"],
         variables=["x", "y", "z"],
-        image_mapping={
-            "x": "pikachu.png",
-            "y": "bulbasaur.png",
-            "z": "charmander.png"
-        },
+        image_mapping={"x": "pikachu.png", "y": "bulbasaur.png", "z": "charmander.png"},
         description="A test quiz with simple variables",
         is_random=False,
         difficulty=None,
         next_quiz_id=None,
-        has_next=False
+        has_next=False,
     )
 
 
@@ -43,13 +39,13 @@ def problematic_quiz_view_model():
         image_mapping={
             "x": "pikachu.png",
             "y": "bulbasaur.png",
-            "z": "quaxly.png"  # Pokémon name contains 'x' which is also a variable
+            "z": "quaxly.png",  # Pokémon name contains 'x' which is also a variable
         },
         description="A quiz with problematic variable and Pokémon names",
         is_random=False,
         difficulty=None,
         next_quiz_id=None,
-        has_next=False
+        has_next=False,
     )
 
 
@@ -57,12 +53,12 @@ def test_replace_variables_with_images_basic(basic_quiz_view_model):
     """Test basic variable replacement in simple equations."""
     equation = "x + 10 = y"
     result = basic_quiz_view_model.replace_variables_with_images(equation)
-    
+
     # Check that variables were replaced with image tags
     assert 'src="/static/images/pikachu.png"' in result  # x
     assert 'src="/static/images/bulbasaur.png"' in result  # y
     assert 'class="pokemon-var"' in result
-    
+
     # The equation should no longer contain the original variable names as standalone variables
     assert " x " not in result
     assert " y " not in result
@@ -74,12 +70,12 @@ def test_replace_variables_with_images_bug(problematic_quiz_view_model):
     # For example, when debugging or showing the image mapping
     image_path = "quaxly.png"  # This contains 'x' which is also a variable
     result = problematic_quiz_view_model.replace_variables_with_images(image_path)
-    
+
     # The bug: 'x' in 'quaxly.png' should not be replaced with an image tag
     # The current implementation will replace 'x' with its image tag, resulting in a mangled path
-    
+
     # The image path should remain unchanged
     assert result == "quaxly.png", "The image path should not be modified"
-    
+
     # It should not contain any image tags
-    assert '<img' not in result, "No HTML tags should be inserted into the image path" 
+    assert "<img" not in result, "No HTML tags should be inserted into the image path"

--- a/tools/get_pr_comments.py
+++ b/tools/get_pr_comments.py
@@ -50,10 +50,7 @@ def main() -> int:
         comment
         for comment in comments
         if not comment.get("resolved")
-        and (
-            not args.author
-            or comment["user"]["login"].lower() == args.author.lower()
-        )
+        and (not args.author or comment["user"]["login"].lower() == args.author.lower())
     ]
     author = f" by '@{args.author}'" if args.author else ""
     if not filtered:

--- a/tools/git_time_calculator.py
+++ b/tools/git_time_calculator.py
@@ -1,116 +1,122 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import argparse
 import subprocess
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import List, Tuple
 
 # Default configuration values
 DEFAULT_BREAK_THRESHOLD_MINUTES = 90
 DEFAULT_PRE_COMMIT_BUFFER_MINUTES = 30
 
+
 @dataclass
 class WorkBlock:
     start: datetime
     end: datetime
-    
+
     @property
     def duration_minutes(self) -> float:
         return (self.end - self.start).total_seconds() / 60
 
+
 @dataclass
 class DayWorkSummary:
     date: str
-    blocks: List[WorkBlock]
-    breaks: List[Tuple[datetime, datetime]]
-    
+    blocks: list[WorkBlock]
+    breaks: list[tuple[datetime, datetime]]
+
     @property
     def total_minutes(self) -> float:
         return sum(block.duration_minutes for block in self.blocks)
-    
+
     @property
     def total_break_minutes(self) -> float:
         return sum((end - start).total_seconds() / 60 for start, end in self.breaks)
 
+
 def get_git_log():
     """Retrieve git log with commit timestamps"""
-    command = ['git', 'log', '--pretty=format:%aI|%an']
+    command = ["git", "log", "--pretty=format:%aI|%an"]
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"Error running git command: {result.stderr}")
         return []
-    
-    return result.stdout.strip().split('\n')
+
+    return result.stdout.strip().split("\n")
+
 
 def parse_git_log(log_entries):
     """Parse git log entries and organize commits by day"""
     commits_by_day = defaultdict(list)
-    
+
     for entry in log_entries:
         try:
-            timestamp_str, author = entry.split('|', 1)
+            timestamp_str, author = entry.split("|", 1)
             timestamp = datetime.fromisoformat(timestamp_str)
             day = timestamp.date().isoformat()
             commits_by_day[day].append(timestamp)
         except (ValueError, IndexError) as e:
             print(f"Error parsing log entry '{entry}': {e}")
             continue
-    
+
     return commits_by_day
+
 
 def calculate_work_time(commits_by_day, break_threshold_minutes, pre_commit_buffer_minutes):
     """Calculate work time for each day, accounting for breaks between commits"""
     daily_summaries = {}
     total_minutes = 0
-    
+
     for day, timestamps in commits_by_day.items():
         # Sort timestamps
         sorted_timestamps = sorted(timestamps)
-        
+
         # Initialize with the first work block
         current_block_start = sorted_timestamps[0] - timedelta(minutes=pre_commit_buffer_minutes)
         current_block_end = sorted_timestamps[0]
-        
+
         work_blocks = []
         breaks = []
-        
+
         # Process all commits to identify work blocks and breaks
         for i in range(1, len(sorted_timestamps)):
-            time_diff = (sorted_timestamps[i] - sorted_timestamps[i-1]).total_seconds() / 60
-            
+            time_diff = (sorted_timestamps[i] - sorted_timestamps[i - 1]).total_seconds() / 60
+
             if time_diff > break_threshold_minutes:
                 # Finish the current block
                 work_blocks.append(WorkBlock(current_block_start, current_block_end))
-                
+
                 # Record the break - must end pre_commit_buffer_minutes before next commit
                 # to avoid overlap with next work session
-                break_start = sorted_timestamps[i-1]
+                break_start = sorted_timestamps[i - 1]
                 break_end = sorted_timestamps[i] - timedelta(minutes=pre_commit_buffer_minutes)
-                
+
                 # Ensure break has positive duration
                 if break_end > break_start:
                     breaks.append((break_start, break_end))
-                
+
                 # Start a new block with pre-commit buffer
-                current_block_start = sorted_timestamps[i] - timedelta(minutes=pre_commit_buffer_minutes)
+                current_block_start = sorted_timestamps[i] - timedelta(
+                    minutes=pre_commit_buffer_minutes
+                )
                 current_block_end = sorted_timestamps[i]
             else:
                 # Extend the current block
                 current_block_end = sorted_timestamps[i]
-        
+
         # Add the final block
         work_blocks.append(WorkBlock(current_block_start, current_block_end))
-        
+
         # Create the day summary
         daily_summaries[day] = DayWorkSummary(date=day, blocks=work_blocks, breaks=breaks)
-        
+
         # Add to total work time
         total_minutes += daily_summaries[day].total_minutes
-    
+
     return daily_summaries, total_minutes
+
 
 def format_time(minutes):
     """Format minutes as hours and minutes"""
@@ -118,9 +124,11 @@ def format_time(minutes):
     remaining_minutes = int(minutes % 60)
     return f"{hours}h {remaining_minutes}m"
 
+
 def format_datetime(dt):
     """Format datetime for display"""
-    return dt.strftime('%H:%M')
+    return dt.strftime("%H:%M")
+
 
 def parse_arguments():
     """Parse command line arguments"""
@@ -137,84 +145,84 @@ Examples:
   # Set pre-commit buffer to 15 minutes and break threshold to 40 minutes
   python tools/git_time_calculator.py --pre-commit-buffer 15 --break-threshold 40
 """,
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
     parser.add_argument(
-        "--break-threshold", 
+        "--break-threshold",
         type=int,
         default=DEFAULT_BREAK_THRESHOLD_MINUTES,
-        help=f"Minutes between commits that constitute a break (default: {DEFAULT_BREAK_THRESHOLD_MINUTES})"
+        help=f"Minutes between commits that constitute a break (default: {DEFAULT_BREAK_THRESHOLD_MINUTES})",
     )
-    
+
     parser.add_argument(
         "--pre-commit-buffer",
         type=int,
         default=DEFAULT_PRE_COMMIT_BUFFER_MINUTES,
-        help=f"Minutes of work before first commit in a session (default: {DEFAULT_PRE_COMMIT_BUFFER_MINUTES})"
+        help=f"Minutes of work before first commit in a session (default: {DEFAULT_PRE_COMMIT_BUFFER_MINUTES})",
     )
-    
+
     return parser.parse_args()
+
 
 def main():
     args = parse_arguments()
-    
+
     print("Analyzing git log to calculate work time...")
     print(f"Using break threshold: {args.break_threshold} minutes")
     print(f"Using pre-commit buffer: {args.pre_commit_buffer} minutes")
-    
+
     log_entries = get_git_log()
-    
+
     if not log_entries:
         print("No git log entries found.")
         return
-    
+
     commits_by_day = parse_git_log(log_entries)
     daily_summaries, total_minutes = calculate_work_time(
-        commits_by_day, 
-        args.break_threshold, 
-        args.pre_commit_buffer
+        commits_by_day, args.break_threshold, args.pre_commit_buffer
     )
-    
+
     print("\n📊 WORK TIME BREAKDOWN BY DAY")
     print("=" * 80)
-    
+
     for day, summary in sorted(daily_summaries.items()):
         day_total = format_time(summary.total_minutes)
         print(f"\n📅 {day} - Total work time: {day_total}")
-        
+
         print("\n  🔄 Work Sessions:")
         print("  " + "-" * 76)
         print("  |  Start  |   End   | Duration |                                           |")
         print("  " + "-" * 76)
-        
+
         for i, block in enumerate(summary.blocks, 1):
             start_time = format_datetime(block.start)
             end_time = format_datetime(block.end)
             duration = format_time(block.duration_minutes)
             print(f"  | {start_time} | {end_time} | {duration:^8} | Session {i:<38} |")
-        
+
         print("  " + "-" * 76)
-        
+
         if summary.breaks:
             print("\n  ⏸️  Breaks:")
             print("  " + "-" * 76)
             print("  |  Start  |   End   | Duration |                                           |")
             print("  " + "-" * 76)
-            
+
             for i, (break_start, break_end) in enumerate(summary.breaks, 1):
                 start_time = format_datetime(break_start)
                 end_time = format_datetime(break_end)
                 duration = format_time((break_end - break_start).total_seconds() / 60)
                 print(f"  | {start_time} | {end_time} | {duration:^8} | Break {i:<39} |")
-            
+
             print("  " + "-" * 76)
-        
+
         print()
-    
+
     print("=" * 80)
     print(f"⏱️  Total time spent on the project: {format_time(total_minutes)}")
     print("=" * 80)
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/tools/private_cloud_run_proxy.py
+++ b/tools/private_cloud_run_proxy.py
@@ -68,10 +68,7 @@ def handler_for(service_url: str, token: str):
 
             self.send_response(upstream.status_code)
             for name, value in upstream.headers.items():
-                if (
-                    name.lower() not in HOP_BY_HOP_HEADERS
-                    and name.lower() != "set-cookie"
-                ):
+                if name.lower() not in HOP_BY_HOP_HEADERS and name.lower() != "set-cookie":
                     self.send_header(name, value)
             # Production must keep Secure cookies. The localhost HTTP proxy
             # removes that attribute only on its downstream test response so

--- a/tools/progression_plotter.py
+++ b/tools/progression_plotter.py
@@ -18,15 +18,13 @@ import argparse
 import os
 import sys
 import traceback
-from typing import Dict, List
 
 # Add the project root to the Python path to allow importing from src
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Check for required packages
 try:
     import matplotlib.pyplot as plt
-    import numpy as np
 except ImportError as e:
     print(f"Error: {e}")
     print("Please install the required packages with:")
@@ -36,13 +34,6 @@ except ImportError as e:
 # Import project modules
 try:
     from src.app.game.pokemon_selector import PokemonSelector
-    from src.app.game.progression_config import (
-        BASE_XP,
-        DIFFICULTY_MULTIPLIER,
-        TIER_BASE_WEIGHTS,
-        TIER_UNLOCK_LEVELS,
-        XP_MULTIPLIER,
-    )
     from src.app.game.progression_manager import ProgressionManager
 except ImportError as e:
     print(f"Error importing project modules: {e}")
@@ -50,148 +41,137 @@ except ImportError as e:
     sys.exit(1)
 
 
-def calculate_tier_distribution(player_level: int, difficulty: int) -> Dict[int, float]:
+def calculate_tier_distribution(player_level: int, difficulty: int) -> dict[int, float]:
     """
     Calculate the probability distribution of Pokémon tiers for a given player level and difficulty.
-    
+
     Args:
         player_level: Current player level
         difficulty: Adventure difficulty (1-7)
-        
+
     Returns:
         Dictionary mapping tier to probability
     """
     # Get eligible tiers based on player level
     eligible_tiers = PokemonSelector.get_eligible_tiers(player_level)
-    
+
     # Calculate weights for each eligible tier
     weights = {
         tier: PokemonSelector.calculate_adjusted_weight(tier, difficulty, player_level)
         for tier in eligible_tiers
     }
-    
+
     # Calculate total weight
     total_weight = sum(weights.values())
-    
+
     # Calculate probabilities
-    probabilities = {
-        tier: weight / total_weight
-        for tier, weight in weights.items()
-    }
-    
+    probabilities = {tier: weight / total_weight for tier, weight in weights.items()}
+
     return probabilities
 
 
-def calculate_xp_needed_per_level(max_level: int) -> List[int]:
+def calculate_xp_needed_per_level(max_level: int) -> list[int]:
     """
     Calculate XP needed for each level up to max_level.
-    
+
     Args:
         max_level: Maximum level to calculate
-        
+
     Returns:
         List of XP values needed for each level
     """
     return [ProgressionManager.calculate_xp_needed(level) for level in range(1, max_level + 1)]
 
 
-def calculate_cumulative_xp(max_level: int) -> List[int]:
+def calculate_cumulative_xp(max_level: int) -> list[int]:
     """
     Calculate cumulative XP needed to reach each level.
-    
+
     Args:
         max_level: Maximum level to calculate
-        
+
     Returns:
         List of cumulative XP values
     """
     xp_per_level = calculate_xp_needed_per_level(max_level)
     cumulative_xp = []
     total = 0
-    
+
     for xp in xp_per_level:
         total += xp
         cumulative_xp.append(total)
-    
+
     return cumulative_xp
 
 
-def plot_tier_distribution(player_level: int, difficulty: int = None, all_difficulties: bool = False) -> None:
+def plot_tier_distribution(
+    player_level: int, difficulty: int | None = None, all_difficulties: bool = False
+) -> None:
     """
     Plot the distribution of Pokémon tiers for a given player level and difficulty.
-    
+
     Args:
         player_level: Current player level
         difficulty: Adventure difficulty (1-7), or None if all_difficulties is True
         all_difficulties: Whether to plot for all difficulties
     """
     plt.figure(figsize=(10, 6))
-    
+
     # Define colors for each difficulty
-    colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2']
-    
+    colors = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2"]
+
     if all_difficulties:
         # Plot for all difficulties
         difficulties = range(1, 8)  # 1-7
-        
+
         for i, diff in enumerate(difficulties):
             distribution = calculate_tier_distribution(player_level, diff)
-            
+
             # Sort by tier
             tiers = sorted(distribution.keys())
             probabilities = [distribution[tier] for tier in tiers]
-            
+
             plt.bar(
                 [str(tier) for tier in tiers],
                 probabilities,
                 alpha=0.7,
-                label=f'Difficulty {diff}',
-                color=colors[i % len(colors)]
+                label=f"Difficulty {diff}",
+                color=colors[i % len(colors)],
             )
-            
-        plt.title(f'Pokémon Tier Distribution at Level {player_level} (All Difficulties)')
+
+        plt.title(f"Pokémon Tier Distribution at Level {player_level} (All Difficulties)")
         plt.legend()
-        
+
     else:
         # Plot for a single difficulty
         if difficulty is None:
             difficulty = 4  # Default to middle difficulty
-            
+
         distribution = calculate_tier_distribution(player_level, difficulty)
-        
+
         # Sort by tier
         tiers = sorted(distribution.keys())
         probabilities = [distribution[tier] for tier in tiers]
-        
-        plt.bar(
-            [str(tier) for tier in tiers],
-            probabilities,
-            color=colors[0]
-        )
-        
-        plt.title(f'Pokémon Tier Distribution at Level {player_level}, Difficulty {difficulty}')
-    
+
+        plt.bar([str(tier) for tier in tiers], probabilities, color=colors[0])
+
+        plt.title(f"Pokémon Tier Distribution at Level {player_level}, Difficulty {difficulty}")
+
     # Add tier labels
-    tier_labels = {
-        1: "Common",
-        2: "Uncommon",
-        3: "Rare",
-        4: "Very Rare",
-        5: "Legendary"
-    }
-    
-    plt.xlabel('Pokémon Tier')
-    plt.ylabel('Probability')
-    
+    tier_labels = {1: "Common", 2: "Uncommon", 3: "Rare", 4: "Very Rare", 5: "Legendary"}
+
+    plt.xlabel("Pokémon Tier")
+    plt.ylabel("Probability")
+
     # Add tier names to x-axis
     plt.xticks(
         [str(tier) for tier in sorted(tier_labels.keys())],
-        [f"{tier} - {tier_labels[tier]}" for tier in sorted(tier_labels.keys())]
+        [f"{tier} - {tier_labels[tier]}" for tier in sorted(tier_labels.keys())],
     )
-    
+
     plt.ylim(0, 1)
-    plt.grid(axis='y', linestyle='--', alpha=0.7)
-    
+    plt.grid(axis="y", linestyle="--", alpha=0.7)
+
     plt.tight_layout()
     plt.show()
 
@@ -199,97 +179,108 @@ def plot_tier_distribution(player_level: int, difficulty: int = None, all_diffic
 def plot_xp_curve(max_level: int) -> None:
     """
     Plot the XP curve showing XP needed for each level and cumulative XP.
-    
+
     Args:
         max_level: Maximum level to plot
     """
     levels = list(range(1, max_level + 1))
     xp_per_level = calculate_xp_needed_per_level(max_level)
     cumulative_xp = calculate_cumulative_xp(max_level)
-    
+
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 6))
-    
+
     # Plot XP needed per level
-    ax1.plot(levels, xp_per_level, 'o-', color='#1f77b4', linewidth=2)
-    ax1.set_title('XP Needed Per Level')
-    ax1.set_xlabel('Level')
-    ax1.set_ylabel('XP Needed')
-    ax1.grid(True, linestyle='--', alpha=0.7)
-    
+    ax1.plot(levels, xp_per_level, "o-", color="#1f77b4", linewidth=2)
+    ax1.set_title("XP Needed Per Level")
+    ax1.set_xlabel("Level")
+    ax1.set_ylabel("XP Needed")
+    ax1.grid(True, linestyle="--", alpha=0.7)
+
     # Plot cumulative XP
-    ax2.plot(levels, cumulative_xp, 'o-', color='#ff7f0e', linewidth=2)
-    ax2.set_title('Cumulative XP Needed')
-    ax2.set_xlabel('Level')
-    ax2.set_ylabel('Total XP')
-    ax2.grid(True, linestyle='--', alpha=0.7)
-    
+    ax2.plot(levels, cumulative_xp, "o-", color="#ff7f0e", linewidth=2)
+    ax2.set_title("Cumulative XP Needed")
+    ax2.set_xlabel("Level")
+    ax2.set_ylabel("Total XP")
+    ax2.grid(True, linestyle="--", alpha=0.7)
+
     plt.tight_layout()
     plt.show()
 
 
 def setup_tier_parser(subparsers):
     """Set up the parser for the tier distribution command."""
-    tier_parser = subparsers.add_parser('tier', help='Plot Pokémon tier distribution')
-    tier_parser.add_argument('--level', type=int, required=True,
-                            help='Player level for tier distribution plot')
-    tier_parser.add_argument('--difficulty', type=int, choices=range(1, 8),
-                            help='Adventure difficulty (1-7) for tier distribution plot')
-    tier_parser.add_argument('--all-difficulties', action='store_true',
-                            help='Plot for all difficulties (1-7)')
+    tier_parser = subparsers.add_parser("tier", help="Plot Pokémon tier distribution")
+    tier_parser.add_argument(
+        "--level", type=int, required=True, help="Player level for tier distribution plot"
+    )
+    tier_parser.add_argument(
+        "--difficulty",
+        type=int,
+        choices=range(1, 8),
+        help="Adventure difficulty (1-7) for tier distribution plot",
+    )
+    tier_parser.add_argument(
+        "--all-difficulties", action="store_true", help="Plot for all difficulties (1-7)"
+    )
     return tier_parser
 
 
 def setup_xp_parser(subparsers):
     """Set up the parser for the XP curve command."""
-    xp_parser = subparsers.add_parser('xp', help='Plot XP curves')
-    xp_parser.add_argument('--max-level', type=int, default=50,
-                          help='Maximum level for XP curve plot (default: 50)')
+    xp_parser = subparsers.add_parser("xp", help="Plot XP curves")
+    xp_parser.add_argument(
+        "--max-level", type=int, default=50, help="Maximum level for XP curve plot (default: 50)"
+    )
     return xp_parser
 
 
 def main():
     """Main function to parse arguments and run the appropriate plotting function."""
     parser = argparse.ArgumentParser(
-        description='Plot Pokémon tier distribution and XP curves.',
+        description="Plot Pokémon tier distribution and XP curves.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=__doc__.split('Usage:')[1]
+        epilog=__doc__.split("Usage:")[1],
     )
-    
-    subparsers = parser.add_subparsers(dest='command', help='Command to run')
-    
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
     # Set up subparsers for each command
     setup_tier_parser(subparsers)
     setup_xp_parser(subparsers)
-    
+
     args = parser.parse_args()
-    
+
     if not args.command:
         parser.print_help()
         return
-    
+
     try:
-        if args.command == 'tier':
+        if args.command == "tier":
             if args.all_difficulties:
                 plot_tier_distribution(args.level, all_difficulties=True)
             else:
                 if args.difficulty is None:
-                    print("Error: Either --difficulty or --all-difficulties is required for tier distribution plot")
+                    print(
+                        "Error: Either --difficulty or --all-difficulties is required for tier distribution plot"
+                    )
                     print("Example: python progression_plotter.py tier --level 20 --difficulty 3")
-                    print("Example: python progression_plotter.py tier --level 20 --all-difficulties")
+                    print(
+                        "Example: python progression_plotter.py tier --level 20 --all-difficulties"
+                    )
                     return
                 plot_tier_distribution(args.level, args.difficulty)
-        
-        elif args.command == 'xp':
+
+        elif args.command == "xp":
             plot_xp_curve(args.max_level)
-    
+
     except Exception as e:
-        print(f"Error: {str(e)}")
+        print(f"Error: {e!s}")
         print("Traceback:")
         traceback.print_exc()
         return 1
-    
+
     return 0
 
 
-if __name__ == '__main__':
-    sys.exit(main()) 
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/progression_plotter_gui.py
+++ b/tools/progression_plotter_gui.py
@@ -15,10 +15,9 @@ Usage:
 import os
 import sys
 import traceback
-from typing import Dict, List
 
 # Add the project root to the Python path to allow importing from src
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Check for required packages
 try:
@@ -26,7 +25,6 @@ try:
     from tkinter import messagebox, ttk
 
     import matplotlib.pyplot as plt
-    import numpy as np
     from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 except ImportError as e:
     print(f"Error: {e}")
@@ -38,13 +36,6 @@ except ImportError as e:
 # Import project modules
 try:
     from src.app.game.pokemon_selector import PokemonSelector
-    from src.app.game.progression_config import (
-        BASE_XP,
-        DIFFICULTY_MULTIPLIER,
-        TIER_BASE_WEIGHTS,
-        TIER_UNLOCK_LEVELS,
-        XP_MULTIPLIER,
-    )
     from src.app.game.progression_manager import ProgressionManager
 except ImportError as e:
     print(f"Error importing project modules: {e}")
@@ -52,86 +43,83 @@ except ImportError as e:
     sys.exit(1)
 
 
-def calculate_tier_distribution(player_level: int, difficulty: int) -> Dict[int, float]:
+def calculate_tier_distribution(player_level: int, difficulty: int) -> dict[int, float]:
     """Calculate the probability distribution of Pokémon tiers."""
     eligible_tiers = PokemonSelector.get_eligible_tiers(player_level)
-    
+
     weights = {
         tier: PokemonSelector.calculate_adjusted_weight(tier, difficulty, player_level)
         for tier in eligible_tiers
     }
-    
+
     total_weight = sum(weights.values())
-    
-    probabilities = {
-        tier: weight / total_weight
-        for tier, weight in weights.items()
-    }
-    
+
+    probabilities = {tier: weight / total_weight for tier, weight in weights.items()}
+
     return probabilities
 
 
-def calculate_xp_needed_per_level(max_level: int) -> List[int]:
+def calculate_xp_needed_per_level(max_level: int) -> list[int]:
     """Calculate XP needed for each level up to max_level."""
     return [ProgressionManager.calculate_xp_needed(level) for level in range(1, max_level + 1)]
 
 
-def calculate_cumulative_xp(max_level: int) -> List[int]:
+def calculate_cumulative_xp(max_level: int) -> list[int]:
     """Calculate cumulative XP needed to reach each level."""
     xp_per_level = calculate_xp_needed_per_level(max_level)
     cumulative_xp = []
     total = 0
-    
+
     for xp in xp_per_level:
         total += xp
         cumulative_xp.append(total)
-    
+
     return cumulative_xp
 
 
 class ProgressionPlotterApp:
     """Main application class for the Progression Plotter GUI."""
-    
+
     def __init__(self, root):
         self.root = root
         self.root.title("PokeMath Progression Plotter")
         self.root.geometry("1000x700")
         self.root.minsize(800, 600)
-        
+
         # Set up the main frame
         self.main_frame = ttk.Frame(root, padding="10")
         self.main_frame.pack(fill=tk.BOTH, expand=True)
-        
+
         # Create tabs
         self.tab_control = ttk.Notebook(self.main_frame)
-        
+
         self.tier_tab = ttk.Frame(self.tab_control)
         self.xp_tab = ttk.Frame(self.tab_control)
-        
+
         self.tab_control.add(self.tier_tab, text="Tier Distribution")
         self.tab_control.add(self.xp_tab, text="XP Curves")
-        
+
         self.tab_control.pack(fill=tk.BOTH, expand=True)
-        
+
         # Set up the tier distribution tab
         self.setup_tier_tab()
-        
+
         # Set up the XP curves tab
         self.setup_xp_tab()
-        
+
         # Add help menu
         self.create_menu()
-    
+
     def create_menu(self):
         """Create the application menu."""
         menu_bar = tk.Menu(self.root)
         self.root.config(menu=menu_bar)
-        
+
         # Help menu
         help_menu = tk.Menu(menu_bar, tearoff=0)
         menu_bar.add_cascade(label="Help", menu=help_menu)
         help_menu.add_command(label="About", command=self.show_about)
-    
+
     def show_about(self):
         """Show the about dialog."""
         messagebox.showinfo(
@@ -140,198 +128,206 @@ class ProgressionPlotterApp:
             "A tool for visualizing Pokémon tier distribution and XP curves in PokeMath.\n\n"
             "This tool helps understand:\n"
             "1. The distribution of Pokémon tiers based on player level and difficulty\n"
-            "2. XP curves showing progression through levels"
+            "2. XP curves showing progression through levels",
         )
-    
+
     def setup_tier_tab(self):
         """Set up the tier distribution tab."""
         # Control frame
         control_frame = ttk.LabelFrame(self.tier_tab, text="Controls", padding="10")
         control_frame.pack(fill=tk.X, padx=10, pady=10)
-        
+
         # Level selection
-        ttk.Label(control_frame, text="Player Level:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
+        ttk.Label(control_frame, text="Player Level:").grid(
+            row=0, column=0, sticky=tk.W, padx=5, pady=5
+        )
         self.level_var = tk.IntVar(value=20)
-        level_spinner = ttk.Spinbox(control_frame, from_=1, to=100, textvariable=self.level_var, width=5)
+        level_spinner = ttk.Spinbox(
+            control_frame, from_=1, to=100, textvariable=self.level_var, width=5
+        )
         level_spinner.grid(row=0, column=1, sticky=tk.W, padx=5, pady=5)
-        
+
         # Difficulty selection
-        ttk.Label(control_frame, text="Difficulty:").grid(row=0, column=2, sticky=tk.W, padx=5, pady=5)
+        ttk.Label(control_frame, text="Difficulty:").grid(
+            row=0, column=2, sticky=tk.W, padx=5, pady=5
+        )
         self.difficulty_var = tk.IntVar(value=4)
-        difficulty_spinner = ttk.Spinbox(control_frame, from_=1, to=7, textvariable=self.difficulty_var, width=5)
+        difficulty_spinner = ttk.Spinbox(
+            control_frame, from_=1, to=7, textvariable=self.difficulty_var, width=5
+        )
         difficulty_spinner.grid(row=0, column=3, sticky=tk.W, padx=5, pady=5)
-        
+
         # All difficulties checkbox
         self.all_difficulties_var = tk.BooleanVar(value=False)
         all_difficulties_check = ttk.Checkbutton(
-            control_frame, 
-            text="Show All Difficulties", 
-            variable=self.all_difficulties_var
+            control_frame, text="Show All Difficulties", variable=self.all_difficulties_var
         )
         all_difficulties_check.grid(row=0, column=4, sticky=tk.W, padx=5, pady=5)
-        
+
         # Plot button
         plot_button = ttk.Button(control_frame, text="Plot", command=self.plot_tier_distribution)
         plot_button.grid(row=0, column=5, sticky=tk.E, padx=5, pady=5)
-        
+
         # Figure frame
         self.tier_figure_frame = ttk.Frame(self.tier_tab)
         self.tier_figure_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
-        
+
         # Create initial plot
         self.plot_tier_distribution()
-    
+
     def setup_xp_tab(self):
         """Set up the XP curves tab."""
         # Control frame
         control_frame = ttk.LabelFrame(self.xp_tab, text="Controls", padding="10")
         control_frame.pack(fill=tk.X, padx=10, pady=10)
-        
+
         # Max level selection
-        ttk.Label(control_frame, text="Max Level:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
+        ttk.Label(control_frame, text="Max Level:").grid(
+            row=0, column=0, sticky=tk.W, padx=5, pady=5
+        )
         self.max_level_var = tk.IntVar(value=50)
-        max_level_spinner = ttk.Spinbox(control_frame, from_=1, to=100, textvariable=self.max_level_var, width=5)
+        max_level_spinner = ttk.Spinbox(
+            control_frame, from_=1, to=100, textvariable=self.max_level_var, width=5
+        )
         max_level_spinner.grid(row=0, column=1, sticky=tk.W, padx=5, pady=5)
-        
+
         # Plot button
         plot_button = ttk.Button(control_frame, text="Plot", command=self.plot_xp_curves)
         plot_button.grid(row=0, column=2, sticky=tk.E, padx=5, pady=5)
-        
+
         # Figure frame
         self.xp_figure_frame = ttk.Frame(self.xp_tab)
         self.xp_figure_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
-        
+
         # Create initial plot
         self.plot_xp_curves()
-    
+
     def plot_tier_distribution(self):
         """Plot the tier distribution based on current settings."""
         try:
             # Clear previous plot
             for widget in self.tier_figure_frame.winfo_children():
                 widget.destroy()
-            
+
             # Get values from controls
             player_level = self.level_var.get()
             difficulty = self.difficulty_var.get()
             all_difficulties = self.all_difficulties_var.get()
-            
+
             # Create figure
             fig = plt.Figure(figsize=(10, 6), dpi=100)
             ax = fig.add_subplot(111)
-            
+
             # Define colors for each difficulty
-            colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2']
-            
+            colors = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2"]
+
             if all_difficulties:
                 # Plot for all difficulties
                 difficulties = range(1, 8)  # 1-7
-                
+
                 for i, diff in enumerate(difficulties):
                     distribution = calculate_tier_distribution(player_level, diff)
-                    
+
                     # Sort by tier
                     tiers = sorted(distribution.keys())
                     probabilities = [distribution[tier] for tier in tiers]
-                    
+
                     ax.bar(
                         [str(tier) for tier in tiers],
                         probabilities,
                         alpha=0.7,
-                        label=f'Difficulty {diff}',
-                        color=colors[i % len(colors)]
+                        label=f"Difficulty {diff}",
+                        color=colors[i % len(colors)],
                     )
-                    
-                ax.set_title(f'Pokémon Tier Distribution at Level {player_level} (All Difficulties)')
+
+                ax.set_title(
+                    f"Pokémon Tier Distribution at Level {player_level} (All Difficulties)"
+                )
                 ax.legend()
-                
+
             else:
                 # Plot for a single difficulty
                 distribution = calculate_tier_distribution(player_level, difficulty)
-                
+
                 # Sort by tier
                 tiers = sorted(distribution.keys())
                 probabilities = [distribution[tier] for tier in tiers]
-                
-                ax.bar(
-                    [str(tier) for tier in tiers],
-                    probabilities,
-                    color=colors[0]
+
+                ax.bar([str(tier) for tier in tiers], probabilities, color=colors[0])
+
+                ax.set_title(
+                    f"Pokémon Tier Distribution at Level {player_level}, Difficulty {difficulty}"
                 )
-                
-                ax.set_title(f'Pokémon Tier Distribution at Level {player_level}, Difficulty {difficulty}')
-            
+
             # Add tier labels
-            tier_labels = {
-                1: "Common",
-                2: "Uncommon",
-                3: "Rare",
-                4: "Very Rare",
-                5: "Legendary"
-            }
-            
-            ax.set_xlabel('Pokémon Tier')
-            ax.set_ylabel('Probability')
-            
+            tier_labels = {1: "Common", 2: "Uncommon", 3: "Rare", 4: "Very Rare", 5: "Legendary"}
+
+            ax.set_xlabel("Pokémon Tier")
+            ax.set_ylabel("Probability")
+
             # Add tier names to x-axis
             ax.set_xticks([str(tier) for tier in sorted(tier_labels.keys())])
-            ax.set_xticklabels([f"{tier} - {tier_labels[tier]}" for tier in sorted(tier_labels.keys())])
-            
+            ax.set_xticklabels(
+                [f"{tier} - {tier_labels[tier]}" for tier in sorted(tier_labels.keys())]
+            )
+
             ax.set_ylim(0, 1)
-            ax.grid(axis='y', linestyle='--', alpha=0.7)
-            
+            ax.grid(axis="y", linestyle="--", alpha=0.7)
+
             fig.tight_layout()
-            
+
             # Add the plot to the frame
             canvas = FigureCanvasTkAgg(fig, master=self.tier_figure_frame)
             canvas.draw()
             canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
         except Exception as e:
-            messagebox.showerror("Error", f"An error occurred while plotting tier distribution: {str(e)}")
+            messagebox.showerror(
+                "Error", f"An error occurred while plotting tier distribution: {e!s}"
+            )
             traceback.print_exc()
-    
+
     def plot_xp_curves(self):
         """Plot the XP curves based on current settings."""
         try:
             # Clear previous plot
             for widget in self.xp_figure_frame.winfo_children():
                 widget.destroy()
-            
+
             # Get values from controls
             max_level = self.max_level_var.get()
-            
+
             # Create figure
             fig = plt.Figure(figsize=(10, 6), dpi=100)
-            
+
             # Plot XP needed per level
             ax1 = fig.add_subplot(121)
             levels = list(range(1, max_level + 1))
             xp_per_level = calculate_xp_needed_per_level(max_level)
-            
-            ax1.plot(levels, xp_per_level, 'o-', color='#1f77b4', linewidth=2)
-            ax1.set_title('XP Needed Per Level')
-            ax1.set_xlabel('Level')
-            ax1.set_ylabel('XP Needed')
-            ax1.grid(True, linestyle='--', alpha=0.7)
-            
+
+            ax1.plot(levels, xp_per_level, "o-", color="#1f77b4", linewidth=2)
+            ax1.set_title("XP Needed Per Level")
+            ax1.set_xlabel("Level")
+            ax1.set_ylabel("XP Needed")
+            ax1.grid(True, linestyle="--", alpha=0.7)
+
             # Plot cumulative XP
             ax2 = fig.add_subplot(122)
             cumulative_xp = calculate_cumulative_xp(max_level)
-            
-            ax2.plot(levels, cumulative_xp, 'o-', color='#ff7f0e', linewidth=2)
-            ax2.set_title('Cumulative XP Needed')
-            ax2.set_xlabel('Level')
-            ax2.set_ylabel('Total XP')
-            ax2.grid(True, linestyle='--', alpha=0.7)
-            
+
+            ax2.plot(levels, cumulative_xp, "o-", color="#ff7f0e", linewidth=2)
+            ax2.set_title("Cumulative XP Needed")
+            ax2.set_xlabel("Level")
+            ax2.set_ylabel("Total XP")
+            ax2.grid(True, linestyle="--", alpha=0.7)
+
             fig.tight_layout()
-            
+
             # Add the plot to the frame
             canvas = FigureCanvasTkAgg(fig, master=self.xp_figure_frame)
             canvas.draw()
             canvas.get_tk_widget().pack(fill=tk.BOTH, expand=True)
         except Exception as e:
-            messagebox.showerror("Error", f"An error occurred while plotting XP curves: {str(e)}")
+            messagebox.showerror("Error", f"An error occurred while plotting XP curves: {e!s}")
             traceback.print_exc()
 
 
@@ -343,11 +339,11 @@ def main():
         root.mainloop()
         return 0
     except Exception as e:
-        print(f"Error: {str(e)}")
+        print(f"Error: {e!s}")
         print("Traceback:")
         traceback.print_exc()
         return 1
 
 
-if __name__ == '__main__':
-    sys.exit(main()) 
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_mypy.py
+++ b/tools/run_mypy.py
@@ -12,21 +12,22 @@ def main():
     """Run mypy on the project."""
     project_root = Path(__file__).parent.parent
     src_dir = project_root / "src"
-    
+
     print("Running mypy type checking...")
     result = subprocess.run(
         ["mypy", str(src_dir)],
         capture_output=True,
         text=True,
     )
-    
+
     print(result.stdout)
-    
+
     if result.stderr:
         print("Errors:", file=sys.stderr)
         print(result.stderr, file=sys.stderr)
-    
+
     return result.returncode
 
+
 if __name__ == "__main__":
-    sys.exit(main()) 
+    sys.exit(main())


### PR DESCRIPTION
### Motivation
- Simplify and modernize the project's Ruff configuration to a small, explicit, Python-3.11-focused setup with sensible defaults for a small personal project. 
- Enforce consistent formatting and a slightly stronger lint set (bugbear, pyflakes, pycodestyle, isort, ruff rules, pyupgrade) to catch common issues and enable straightforward autofixes. 
- Reduce noise from legacy lint findings and move the codebase toward modern, idiomatic Python (PEP 585/604 types, explicit exports, safer exception handling). 

### Description
- Replace the Ruff config in `pyproject.toml` with a KISS configuration that sets `line-length = 100`, `src` roots, `target-version = "py311"`, ignores `E501`, and enables `B`, `E`, `F`, `I`, `RUF`, and `UP` rule families. 
- Apply `ruff` formatting across the repository and run autofixes to address many findings, and keep the code style consistent (quotes, spacing, trailing commas, etc.). 
- Fix concrete lint issues across multiple modules including: modernizing type annotations to built-in generics and `X | Y` unions, replacing bare `except` with `except Exception`, removing unused imports (notably stray `numpy` uses in plotting tools), adding an explicit `__all__` in `src/app/game/__init__.py`, and small logic/formatting cleanups in many files. 
- Preserve runtime import checks in tooling and keep plotting utilities runnable while removing unused dependencies from immediate imports so Ruff no longer reports them as unused. 

### Testing
- Dependency sync was run with `uv sync --locked --all-groups` and completed successfully. 
- Ruff formatting and lint checks were run with `uv run ruff format --check .` and `uv run ruff check .` and reported no remaining issues. 
- Unit tests were executed with `uv run pytest tests/unit -q` and all unit tests passed (`74 passed` in the run). 
- Repository-level Docker test builds specified in the repository validation were not executed in this environment because Docker is not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e24b707e88323a0f77382786434c0)